### PR TITLE
Revert "Change accent colors image example to html"

### DIFF
--- a/visual-style.html
+++ b/visual-style.html
@@ -245,44 +245,7 @@
 						<p>Accent colors are used to emphasise actions and highlight key information. Blue is a natural choice in our context, where it has been the default color used for links, conveying the idea of action.</p>
 						<p>There are three shades provided for situations where you need a lighter (Accent90), regular (Accent50) or a darker (Accent10) version.</p>
 						<p>Accent50 provides a blue which is suitable to be used for text and as background. When used as link text  it provides sufficient contrast with black text to notice the difference. When used as background, it provides enough contrast with white text to keep the text readable.</p>
-						<div class="color-palette color-section">
-+							<ol>
-+								<li class="color">
-+									<div class="color__swatch" style="background-color: #eaf3ff;">
-+										<strong class="color__name">Accent90</strong>
-+										<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-+									</div>
-+									<div class="color__codes">
-+										<code class="color-code color-code--hex">#eaf3ff</code>
-+										<code class="color-code color-code--rgb">RGB 234, 243, 255</code>
-+										<code class="color-code color-code--hsb">HSB 214, 8%, 100%</code>
-+									</div>
-+								</li>
-+								<li class="color color--dark">
-+									<div class="color__swatch" style="background-color: #36c;">
-+										<strong class="color__name">Accent50</strong>
-+										<span class="color__type">Progressive</span>
-+										<span class="color__wcag-level" title="WCAG conformance level">AA</span>
-+									</div>
-+									<div class="color__codes">
-+										<code class="color-code color-code--hex">#36c</code>
-+										<code class="color-code color-code--rgb">RGB 51, 102, 204</code>
-+										<code class="color-code color-code--hsb">HSB 220, 75%, 80%</code>
-+									</div>
-+								</li>
-+								<li class="color color--dark">
-+									<div class="color__swatch" style="background-color: #2a4b8d;">
-+										<strong class="color__name">Accent10</strong>
-+										<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-+									</div>
-+									<div class="color__codes">
-+										<code class="color-code color-code--hex">#2a4b8d</code>
-+										<code class="color-code color-code--rgb">RGB 42, 75, 141</code>
-+										<code class="color-code color-code--hsb">HSB 220, 70%, 55%</code>
-+									</div>
-+								</li>								
-+							</ol>
-+						</div>
+						<img src="img/colors-accent.png" alt="Accent colors">
 
 						<h3>Utility colors</h3>
 						<p>Red, green and yellow are utility colors. They can act as accent colors bringing the additional meaning that is commonly associated with them.</p>


### PR DESCRIPTION
Reverts wikimedia/WikimediaUI-Style-Guide#12
The HTML includes control characters. Also please try to follow https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines for your commit messages.