### PR TITLE
Change utility colors example image to HTML

### DIFF
--- a/visual-style.html
+++ b/visual-style.html
@@ -286,7 +286,118 @@
 
 						<h3>Utility colors</h3>
 						<p>Red, green and yellow are utility colors. They can act as accent colors bringing the additional meaning that is commonly associated with them.</p>
-						<img src="img/colors-utility.png" alt="Utility colors">
+						<div class="color-palette color-section">
+							<ol>
+								<li class="color">
+									<div class="color__swatch" style="background-color: #fee7e6;">
+										<strong class="color__name">Red90</strong>
+										<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+									</div>
+									<div class="color__codes">
+										<code class="color-code color-code--hex">#fee7e6</code>
+										<code class="color-code color-code--rgb">RGB 255, 231, 230</code>
+										<code class="color-code color-code--hsb">HSB 2, 10%, 100%</code>
+									</div>
+								</li>
+								<li class="color color--dark">
+									<div class="color__swatch" style="background-color: #d33;">
+										<strong class="color__name">Red50</strong>
+										<span class="color__type">Destructive</span>
+										<span class="color__wcag-level" title="WCAG conformance level">AA / <span>AA</span></span>
+									</div>
+									<div class="color__codes">
+										<code class="color-code color-code--hex">#d33</code>
+										<code class="color-code color-code--rgb">RGB 221, 51, 51</code>
+										<code class="color-code color-code--hsb">HSB 360, 77%, 87%</code>
+									</div>
+								</li>
+								<li class="color color--dark">
+									<div class="color__swatch" style="background-color: #873636;">
+										<strong class="color__name">Red10</strong>
+										<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+									</div>
+									<div class="color__codes">
+										<code class="color-code color-code--hex">#873636</code>
+										<code class="color-code color-code--rgb">RGB 135, 54, 54</code>
+										<code class="color-code color-code--hsb">HSB 360, 60%, 53%</code>
+									</div>
+								</li>								
+							</ol>
+						</div>
+						<div class="color-palette color-section">
+							<ol>
+								<li class="color">
+									<div class="color__swatch" style="background-color: #d5fdf4;">
+										<strong class="color__name">Green90</strong>
+										<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+									</div>
+									<div class="color__codes">
+										<code class="color-code color-code--hex">#d5fdf4</code>
+										<code class="color-code color-code--rgb">RGB 213, 253, 244</code>
+										<code class="color-code color-code--hsb">HSB 167, 16%, 99%</code>
+									</div>
+								</li>
+								<li class="color">
+									<div class="color__swatch" style="background-color: #00af89;">
+										<strong class="color__name">Green50</strong>
+										<span class="color__wcag-level" title="WCAG conformance level">AA</span>
+									</div>
+									<div class="color__codes">
+										<code class="color-code color-code--hex">#00af89</code>
+										<code class="color-code color-code--rgb">RGB 0, 175, 137</code>
+										<code class="color-code color-code--hsb">HSB 167, 100%, 69%</code>
+									</div>
+								</li>
+								<li class="color color--dark">
+									<div class="color__swatch" style="background-color: #14866d;">
+										<strong class="color__name">Green30</strong>
+										<span class="color__wcag-level" title="WCAG conformance level">AA</span>
+									</div>
+									<div class="color__codes">
+										<code class="color-code color-code--hex">#14866d</code>
+										<code class="color-code color-code--rgb">RGB 20, 134, 109</code>
+										<code class="color-code color-code--hsb">HSB 167, 85%, 53%</code>
+									</div>
+								</li>								
+							</ol>
+						</div>
+						<div class="color-palette color-section">
+							<ol>
+								<li class="color">
+									<div class="color__swatch" style="background-color: #fef6e7;">
+										<strong class="color__name">Yellow90</strong>
+										<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+									</div>
+									<div class="color__codes">
+										<code class="color-code color-code--hex">#fef6e7</code>
+										<code class="color-code color-code--rgb">RGB 254, 246, 231</code>
+										<code class="color-code color-code--hsb">HSB 39, 9%, 100%</code>
+									</div>
+								</li>
+								<li class="color">
+									<div class="color__swatch" style="background-color: #fc3;">
+										<strong class="color__name">Yellow50</strong>
+										<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+									</div>
+									<div class="color__codes">
+										<code class="color-code color-code--hex">#fc3</code>
+										<code class="color-code color-code--rgb">RGB 255, 204, 51</code>
+										<code class="color-code color-code--hsb">HSB 45, 80%, 100%</code>
+									</div>
+								</li>
+								<li class="color color--dark">
+									<div class="color__swatch" style="background-color: #ac6600;">
+										<strong class="color__name">Yellow30</strong>
+										<span class="color__wcag-level" title="WCAG conformance level">AA</span>
+									</div>
+									<div class="color__codes">
+										<code class="color-code color-code--hex">#ac6600</code>
+										<code class="color-code color-code--rgb">RGB 172, 102, 0</code>
+										<code class="color-code color-code--hsb">HSB 36, 100%, 67%</code>
+									</div>
+								</li>								
+							</ol>
+						</div>
 
 						<h3>Additional colors</h3>
 						<p>Some use cases, such as charts and data visualization, may need a broader color palette. Make sure to aim for level AA contrast (4.5:1) when extending the default palette. Also try to test how they are perceived at different color vision deficiency conditions.</p>


### PR DESCRIPTION
Bug: [T158471](https://phabricator.wikimedia.org/T158471)

Without any CSS edits. I dont know, Grunt have been always deleted CSS rules for needed selectors.