### PR TITLE
layout: Align heading structure to other “Visual Style” sub-pages

### DIFF
--- a/visual-style.html
+++ b/visual-style.html
@@ -59,7 +59,8 @@
 			</div>
 			<div class="col col--end">
 				<main id="content" class="content" role="main">
-					<h1 class="page__title">Visual Style Principles</h1>
+					<div class="page__parent-title">Visual Style</div>
+					<h1 class="page__title">Principles</h1>
 					<p>Wikimedia projects are associated with learning, editorship, and books. They are neutral and transparent. They are about reading and writing. <!-- They remind you of ink and paper. --></p>
 
 					<p>Wikipedia is our most prominent project. <br>It's an encyclopedia. It's a modern encyclopedia. We have a certain perception of visual identity when we talk about encyclopedias. An identity which reflects wisdom. At the same time, traditional encyclopedias have a dated look and feel. This is also the big difference between traditional knowledge sharing and Wikipedia.


### PR DESCRIPTION
Aligning heading structure to other “Visual Style” sub-pages as it
is more harmonious and doesn't mislead “Principles” as overview page.

Bug: T162487