### PR TITLE
Clarifying the Charter/Charis relationship

### DIFF
--- a/visual-style_typography.html
+++ b/visual-style_typography.html
@@ -102,9 +102,9 @@
 					</ul>
 
 					<h3>Typefaces</h3>
-					<p>Charter and Lato are the recommended typefaces, when available.</p>
+					<p>Charter (supported by the Charis SIL font implementation) and Lato are the recommended typefaces, when available.</p>
 					<ul>
-						<li><a href="https://en.wikipedia.org/wiki/Bitstream_Charter">Charter</a> is a serif typeface designed by Matthew Carter in 1987. Charter has a simplified and clean structure that works well even in low resolution displays.</li>
+						<li>Charter is a serif typeface designed by Matthew Carter in 1987. Charter has a simplified and clean structure that works well even in low resolution displays. Although <a href="https://en.wikipedia.org/wiki/Bitstream_Charter">Bitstream Charter</a> is the original implementation for Charter, we recommend using <a href="https://en.wikipedia.org/wiki/Charis_SIL">Charis SIL</a> since it provides a wider Unicode support.</li>
 						<li><a href="http://www.latofonts.com/lato-free-fonts/">Lato</a> is a sans-serif typeface designed by Łukasz Dziedzic in 2010. Lato provides very good readability even at small sizes.</li>
 					</ul>
 					<p>These fonts are provided as a reference, but you may use similar criteria when those fonts are not available in your context.</p>
@@ -117,15 +117,14 @@
 						<li><b>Open.</b> Open source fonts are preferred to align with the open knowledge they deliver.</li>
 					</ol>
 					<p>To extend the font family to new scripts or devices, the above criteria should be followed. Common cases in which you need to look for alternatives are:</p>
-					<p><b>Lack of a font delivery mechanism.</b> In cases where custom fonts cannot be delivered to the user (e.g., through web fonts technology), you need to define alternatives. Default fonts such as Lato and Charter can still be recommended as primary options for users that installed those fonts themselves. However, a wider set of fallback options from those available in the user device is needed. Possible fallback options:</p>
+					<p><b>Lack of a font delivery mechanism.</b> In cases where custom fonts cannot be delivered to the user (e.g., through web fonts technology), you need to define alternatives. Default fonts such as Lato and Charter/Charis can still be recommended as primary options for users that installed those fonts themselves. However, a wider set of fallback options from those available in the user device is needed. Possible fallback options:</p>
 					<ul>
 						<li><a href="https://en.wikipedia.org/wiki/Georgia_(typeface)">Georgia</a> (present in many devices) can be a fallback for Charter.</li>
 						<li>Device default sans-serif font would be used in the absence of Lato.</li>
 					</ul>
 					<p><b>Language support.</b> There is no font that supports all languages. Individual language communities can identify fonts that better support their languages taking into account the above criteria. Possible fallback options:</p>
 					<ul>
-						<li><a href="https://en.wikipedia.org/wiki/Charis_SIL">Charis</a> with a wider script support is a good alternative to Charter.</li>
-						<li>The <a href="https://en.wikipedia.org/wiki/Noto_fonts">Noto family</a> provides a great coverage of languages, making it a good alternative to Lato.</li>
+						<li>The <a href="https://en.wikipedia.org/wiki/Noto_fonts">Noto family</a> provides a great coverage of languages, providing good alternatives for both serif and sans-serif typefaces.</li>
 					</ul>
 
 					<h3>Use of styles</h3>


### PR DESCRIPTION
Presenting Charter as the generic typefaces and making it clear we
recommend Charis as the preferred implementation.