### PR TITLE
build: Update devDependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,33 +12,33 @@
   },
   "private": true,
   "license": "MIT",
+  "dependencies": {
+    "fontfaceobserver": "2.0.9",
+    "normalize.css": "7.0.0",
+    "wikimedia-ui-base": "0.10.0"
+  },
   "devDependencies": {
-    "autoprefixer": "^7.2.5",
-    "cssnano": "^4.0.0-rc.2",
-    "grunt": "1.0.1",
+    "autoprefixer": "8.0.0",
+    "cssnano": "4.0.0-rc.2",
+    "grunt": "1.0.2",
     "grunt-contrib-watch": "1.0.0",
     "grunt-exec": "3.0.0",
-    "grunt-postcss": "^0.9.0",
-    "grunt-sketch": "^1.0.5",
+    "grunt-postcss": "0.9.0",
+    "grunt-sketch": "1.0.5",
     "grunt-stylelint": "0.9.0",
-    "grunt-svgmin": "^5.0.0",
-    "pixrem": "^4.0.1",
-    "postcss": "^6.0.16",
-    "postcss-cssnext": "^3.1.0",
-    "postcss-custom-properties": "^6.2.0",
-    "postcss-import": "^11.0.0",
-    "sketchtool": "^1.4.0",
-    "stylelint": "8.2.0",
+    "grunt-svgmin": "5.0.0",
+    "pixrem": "4.0.1",
+    "postcss": "6.0.16",
+    "postcss-cssnext": "3.1.0",
+    "postcss-custom-properties": "7.0.0",
+    "postcss-import": "11.0.0",
+    "sketchtool": "1.4.0",
+    "stylelint": "9.1.1",
     "stylelint-config-wikimedia": "0.4.2"
-  },
-  "dependencies": {
-    "fontfaceobserver": "^2.0.9",
-    "normalize.css": "^7.0.0",
-    "wikimedia-ui-base": "^0.10.0"
   },
   "scripts": {
     "start": "grunt watch",
-    "build": "grunt", 
+    "build": "grunt",
     "test": "grunt lint"
   }
 }


### PR DESCRIPTION
 autoprefixer               ^7.2.5  →   8.0.0
 grunt                       1.0.1  →   1.0.2
 postcss-custom-properties  ^6.2.0  →   7.0.0
 stylelint                   8.2.0  →   9.1.1

Also removing inconsistently used caret range. We do this manually to
be fully sure not to break anything.
Also putting “dependencies” before “devDependencies”.