### PR TITLE
Fix outdated npm command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ $ npm install
 
 Make your changes. To automatically watch for changes, run:
 ```console
-$ npm run dev
+$ npm run start
 ```
 
 Make sure the tests pass and the CSS for production is built:


### PR DESCRIPTION
Replacing `npm run build` with current `npm run start`.