### PR TITLE
content: Simplify and strengthen “Introduction”

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,28 +60,28 @@
 			<div class="col col--end">
 				<main id="content" class="content" role="main">
 					<h1 class="page__title">Introduction</h1>
-					<p>Wikimedia is a global movement built by a diverse audience.</p>
-					<p>This style guide provides a general design direction for different kinds of interactive projects to serve our diverse communities. Designers and developers will find design recommendations to solve general problems, so that they can focus on the specific needs of their projects.</p>
-					<p>This is an ongoing work, you can always check online <a href="https://wikimedia.github.io/WikimediaUI-Style-Guide/">the latest version of the guide</a>. You are welcome to help make it grow.</p>
+					<p>Wikimedia Design Style Guide is used to bring consistency in how our products look and behave. These guidelines enable interactions between our diverse communities and users. </p>
+					<p>This Style Guide is made to help designers and developers working on Wikimedia projects, either as part of Wikimedia Foundation or in a volunteer capacity. </p>
+					<p>It has unique focus areas like accessibility, internationalization, and localization. </p>
+					<p>Our interfaces are our brand — Wikimedia Design Style Guide also includes visual design principles that drive the aesthetics of our products. </p>
 
-					<section id="how-to-contribute">
-						<h2>How to contribute</h2>
-						<p>You can participate in many ways. The documentation is available in a Git repository with the design assets needed for your project. You can get all of them, change anything and send the changes back.</p>
+					<section id="process">
+						<h2>Our Process</h2>
+						<p>Wikimedia Foundation Design Team maintains the Style Guide. We're a multidisciplinary team with experience in user experience design and research, engineering, information architecture, HCI, visual design, and usability. </p>
+						<p>Our process involves following our <a href="design-principles.html">primary design principles</a> to explore possible solutions for visual identity, user interface components and patterns. </p>
+						<p>Wikimedia Design Style Guide is always evolving and we encourage participation in growing this project. </p>
+					</section>
 
-						<h3>Get the design repository</h3>
-						<p>The <a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/">WikimediaUI Style Guide repository is available to download</a>. It contains this documentation, Sketch and SVG templates and resources. Select the “clone or download” button to get the repository.</p>
-
-						<h3>Commit changes</h3>
-						<p>Easily contribute to the content of the style guide by adding new recommendations, making corrections or adding examples in the form of images or videos: </p>
-						<p>If you have <a href="https://en.wikipedia.org/wiki/Git">Git</a> installed on your system, <a href="https://help.github.com/articles/cloning-a-repository/">cloning</a> is preferred way to get the contents since it allows you to contribute back. Technically changes can be submitted as usual in Git.</p>
-						<p>In order to publish the updated contents to be available live, go to the repo and launch the following command from a terminal: <code>git push -f origin master:gh-pages</code></p>
-						<p>Please add specific topics into a single commit and also take into account the <a href="https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines" target="_blank">Wikimedia commit message guidelines</a>.</p>
-
-						<h3>Contribute beyond content</h3>
-						<p>You can also help to improve how this documentation looks and works.</p>
-						<p>When modifying aspects such as the CSS styling you'll need to rebuild the documentation files using <a href="http://gruntjs.com/">Grunt</a> (which requires <a href="https://docs.npmjs.com/getting-started/installing-node">Node.js and npm</a>). The first time you have to run <code>npm install</code> in a terminal from the style guide's main folder in order to get all necessary dependencies. Every time you want to rebuild the CSS files for the documentation you just need to launch the <code>grunt</code> command in a terminal, also from the main folder.<br>
-						We're using <a href="http://stylelint.io/">stylelint</a> to ensure the CSS <a href="https://github.com/wikimedia/stylelint-config-wikimedia/">aligns with our</a> <a href="https://www.mediawiki.org/wiki/Manual:Coding_conventions/CSS">coding conventions</a>.</p>
-						<p>These requirements provide our contributors a reliable environment and our viewers a performant experience.</p>
+					<section id="how-to-participate">
+						<h2>How to participate</h2>
+						<p>You can engage in many ways:</p>
+						<ul>
+							<li><strong>Request a change or an addition</strong><br><a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=wikimediaui_style_guide" target="_blank">Raise a ticket on our workboard</a> to request a change to the Style Guide</li>
+							<li><strong>Provide feedback</strong><br>Get in touch with us on <a href="https://meta.wikimedia.org/wiki/IRC/Channels#wikimedia-design" target="_blank">IRC</a> or Slack</li>
+							<li><strong>Follow us</strong><br>Follow <a href="https://twitter.com/WikimediaUX" target="_blank">@WikimediaUX on Twitter</a></li>
+							<li><strong>Contribute</strong><br>Read <a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/blob/master/CONTRIBUTING.md" target="_blank">contributing guidelines on Github</a></li>
+							<li><strong>Play around</strong><br><a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/archive/master.zip" target="_blank">Download Wikimedia Design Style Guide</a></li>
+						</ul>
 					</section>
 				</main>
 			</div>


### PR DESCRIPTION
Simplifying and strengthening “Introduction” section by separating
concerns and clearer addressing audiences' needs.
Moving most of contributing out into CONTRIBUTING.md in a next step.

Bug: [T180520](https://phabricator.wikimedia.org/T180520)