### PR TITLE
content: Add `rel="noopener"` to all `target="_blank" attributed links

### DIFF
--- a/design-principles.html
+++ b/design-principles.html
@@ -125,7 +125,7 @@
 				<li><a href="https://twitter.com/@WikimediaUX" title="Follow Wikimedia User Experience team account on Twitter">Follow @WikimediaUX</a></li>
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
-			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
+			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
 			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project">A Wikimedia Foundation project</a></p>
 		</div>
 	</footer>

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
 					<h1 class="page__title">Introduction</h1>
 					<p>Wikimedia Design Style Guide ensures consistency in how our products look and behave. Its guidelines enable interactions between our diverse communities and users. </p>
 					<p>The Style Guide features unique focus areas like accessibility, internationalization, and localization. </p>
-					<p>It aims to help designers and developers with their <a href="https://www.wikimedia.org/" target="_blank">Wikimedia</a> projects, as part of the <a href="https://wikimediafoundation.org/" target="_blank" title="Wikimedia Foundation website">Foundation</a> or in a volunteer capacity. </p>
+					<p>It aims to help designers and developers with their <a href="https://www.wikimedia.org/" target="_blank" rel="noopener">Wikimedia</a> projects, as part of the <a href="https://wikimediafoundation.org/" target="_blank" rel="noopener" title="Wikimedia Foundation website">Foundation</a> or in a volunteer capacity. </p>
 					<p>Our interfaces are our brand. Our visual design principles drive the aesthetics of our products. </p>
 					<section id="process">
 						<h2>Our Process</h2>
@@ -83,11 +83,11 @@
 						<h2>How to participate</h2>
 						<p>You can engage in many ways:</p>
 						<ul>
-							<li><strong>Request a change or an addition</strong><br><a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=wikimediaui_style_guide" target="_blank">Raise a ticket on our workboard</a> to request a change to the Style Guide</li>
-							<li><strong>Provide feedback</strong><br>Get in touch with us on <a href="https://meta.wikimedia.org/wiki/IRC/Channels#wikimedia-design" target="_blank">IRC</a> or Slack</li>
-							<li><strong>Follow us</strong><br>Follow <a href="https://twitter.com/WikimediaUX" target="_blank">@WikimediaUX on Twitter</a></li>
-							<li><strong>Contribute</strong><br>Read <a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/blob/master/CONTRIBUTING.md" target="_blank">contributing guidelines on Github</a></li>
-							<li><strong>Play around</strong><br><a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/archive/master.zip" target="_blank">Download Wikimedia Design Style Guide</a></li>
+							<li><strong>Request a change or an addition</strong><br><a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=wikimediaui_style_guide" target="_blank" rel="noopener">Raise a ticket on our workboard</a> to request a change to the Style Guide</li>
+							<li><strong>Provide feedback</strong><br>Get in touch with us on <a href="https://meta.wikimedia.org/wiki/IRC/Channels#wikimedia-design" target="_blank" rel="noopener">IRC</a> or Slack</li>
+							<li><strong>Follow us</strong><br>Follow <a href="https://twitter.com/WikimediaUX" target="_blank" rel="noopener">@WikimediaUX on Twitter</a></li>
+							<li><strong>Contribute</strong><br>Read <a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/blob/master/CONTRIBUTING.md" target="_blank" rel="noopener">contributing guidelines on Github</a></li>
+							<li><strong>Play around</strong><br><a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/archive/master.zip" target="_blank" rel="noopener">Download Wikimedia Design Style Guide</a></li>
 						</ul>
 					</section>
 				</main>
@@ -101,7 +101,7 @@
 				<li><a href="https://twitter.com/@WikimediaUX" title="Follow Wikimedia User Experience team account on Twitter">Follow @WikimediaUX</a></li>
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
-			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
+			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
 			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project">A Wikimedia Foundation project</a></p>
 		</div>
 	</footer>

--- a/visual-style.html
+++ b/visual-style.html
@@ -81,7 +81,7 @@
 					</figure>
 					<p>We follow our design principles of content first, content precedes chrome.</p>
 					<blockquote>Chrome is the visual design elements that give users information about or commands to operate on the screen's content (as opposed to being part of that content).
-						<cite><a href="https://www.nngroup.com/articles/browser-and-gui-chrome/" target="_blank">Browser and GUI Chrome</a>, Nielsen 2012</cite>
+						<cite><a href="https://www.nngroup.com/articles/browser-and-gui-chrome/" target="_blank" rel="noopener">Browser and GUI Chrome</a>, Nielsen 2012</cite>
 					</blockquote>
 					<p>Content goes on paper, chrome stays on the base layer.</p>
 					<figure>
@@ -103,7 +103,7 @@
 				<li><a href="https://twitter.com/@WikimediaUX" title="Follow Wikimedia User Experience team account on Twitter">Follow @WikimediaUX</a></li>
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
-			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
+			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
 			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project">A Wikimedia Foundation project</a></p>
 		</div>
 	</footer>

--- a/visual-style_colors.html
+++ b/visual-style_colors.html
@@ -62,16 +62,16 @@
 					<div class="page__parent-title">Visual Style</div>
 					<h1 class="page__title">Colors</h1>
 
-					<p>The <a href="https://phabricator.wikimedia.org/M82" target="_blank">color palette</a> represents our character and brings a hint of freshness to our products.</p>
+					<p>The <a href="https://phabricator.wikimedia.org/M82" target="_blank" rel="noopener">color palette</a> represents our character and brings a hint of freshness to our products.</p>
 
 					<img src="img/visual-style/Color-palette-2017-01-15-simplified.png" alt="color palette">
 
-					<p>Making the content readable for everyone was our main goal. Accessibility considerations have been our top priority. Each color in the palette indicates its <a href="https://www.w3.org/WAI/intro/wcag" target="_blank" title="Web Content Accessibility Guidelines 2.0">WCAG</a> conformance level (“AA” or “AAA”). It's based on colors' contrast against white or black.</p>
+					<p>Making the content readable for everyone was our main goal. Accessibility considerations have been our top priority. Each color in the palette indicates its <a href="https://www.w3.org/WAI/intro/wcag" target="_blank" rel="noopener" title="Web Content Accessibility Guidelines 2.0">WCAG</a> conformance level (“AA” or “AAA”). It's based on colors' contrast against white or black.</p>
 
 					<h3>Base colors</h3>
 					<p>Base colors define the content surface and the main color for content. Different shades of paper and ink are useful to emphasise or de-emphasise different content areas.</p>
 					<p>Base colors go from pure white (Base100) to true black (Base0). Intermediate shades of grey include a tint of blue for greater harmony with our accent color.</p>
-					<p>When applying text on a surface, you need to <a href="http://webaim.org/resources/contrastchecker/" target="_blank">check the color contrast</a> between the text and the background: </p>
+					<p>When applying text on a surface, you need to <a href="http://webaim.org/resources/contrastchecker/" target="_blank" rel="noopener">check the color contrast</a> between the text and the background: </p>
 					<ul>
 						<li>Base100…50 are safe text colors for a black surface.</li>
 						<li>Base30…0 are safe text colors for a white surface. </li>
@@ -351,7 +351,7 @@
 				<li><a href="https://twitter.com/@WikimediaUX" title="Follow Wikimedia User Experience team account on Twitter">Follow @WikimediaUX</a></li>
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
-			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
+			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
 			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project">A Wikimedia Foundation project</a></p>
 		</div>
 	</footer>

--- a/visual-style_icons.html
+++ b/visual-style_icons.html
@@ -109,17 +109,17 @@
 					<!-- FIXME: Use of labels -->
 					<p><b>Adapt and remix</b> <br>
 						Our icons are free licensed under CC BY 4.0. <br>
-						The simple style and guidelines make it easy to reuse or adapt existing freely licensed icons that you can find on other repos such as <a href="https://material.io/icons/" target="_blank">Material icons</a> <sup><a href="#References">[3]</a></sup> or the <a href="https://thenounproject.com/" target="_blank">Noun project</a> <sup><a href="#References">[4]</a></sup>. You are welcome to use existing icons that align to the proposed style instead of reinventing the wheel icon.</p>
+						The simple style and guidelines make it easy to reuse or adapt existing freely licensed icons that you can find on other repos such as <a href="https://material.io/icons/" target="_blank" rel="noopener">Material icons</a> <sup><a href="#References">[3]</a></sup> or the <a href="https://thenounproject.com/" target="_blank" rel="noopener">Noun project</a> <sup><a href="#References">[4]</a></sup>. You are welcome to use existing icons that align to the proposed style instead of reinventing the wheel icon.</p>
 
 					<h3>Resources</h3>
 					<p>The <a href="https://doc.wikimedia.org/oojs-ui/master/demos/?page=icons&theme=wikimediaui&direction=ltr&platform=desktop#icons-mediawiki-ltr">OOUI icon repository</a> provides a list of the currently available icons.</p>
 
 					<h3 id="References">References</h3>
 					<ol>
-						<li>Thanks to volunteer contributor <a href="https://phabricator.wikimedia.org/p/SamanthaNguyen/" target="_blank">@SamanthaNguyen</a> for many suggestions on the “Principles” section in icons on <a href="https://phabricator.wikimedia.org/T155684" target="_blank">Phabricator task T155684</a>.</li>
-						<li>1&#160;dp equals 1&#160;px in CSS at 100% zoom level and 1x device. <a href="https://en.wikipedia.org/wiki/Device-independent_pixel" target="_blank">Device-independent pixel on English Wikipedia</a>.</li>
-						<li>Google offers a <a href="https://material.io/guidelines/style/icons.html" target="_blank">Material icons overview and guide to use</a>.</li>
-						<li>The Noun Project provides curated <a href="https://thenounproject.zendesk.com/hc/en-us/articles/200509798-What-licenses-do-you-use-" target="_blank">icon sets that are either Creative Commons Attribution (CC BY) or Public Domain (PD)</a>.</li>
+						<li>Thanks to volunteer contributor <a href="https://phabricator.wikimedia.org/p/SamanthaNguyen/" target="_blank" rel="noopener">@SamanthaNguyen</a> for many suggestions on the “Principles” section in icons on <a href="https://phabricator.wikimedia.org/T155684" target="_blank" rel="noopener">Phabricator task T155684</a>.</li>
+						<li>1&#160;dp equals 1&#160;px in CSS at 100% zoom level and 1x device. <a href="https://en.wikipedia.org/wiki/Device-independent_pixel" target="_blank" rel="noopener">Device-independent pixel on English Wikipedia</a>.</li>
+						<li>Google offers a <a href="https://material.io/guidelines/style/icons.html" target="_blank" rel="noopener">Material icons overview and guide to use</a>.</li>
+						<li>The Noun Project provides curated <a href="https://thenounproject.zendesk.com/hc/en-us/articles/200509798-What-licenses-do-you-use-" target="_blank" rel="noopener">icon sets that are either Creative Commons Attribution (CC BY) or Public Domain (PD)</a>.</li>
 					</ol>
 				</main>
 			</div>
@@ -132,7 +132,7 @@
 				<li><a href="https://twitter.com/@WikimediaUX" title="Follow Wikimedia User Experience team account on Twitter">Follow @WikimediaUX</a></li>
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
-			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
+			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
 			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project">A Wikimedia Foundation project</a></p>
 		</div>
 	</footer>

--- a/visual-style_illustrations.html
+++ b/visual-style_illustrations.html
@@ -85,7 +85,7 @@
 						<li>Rounded corners. Corners are slightly rounded (2&#160;dp) to make shapes more friendly and welcoming, but not too much to look goofy.</li>
 						<li>2&#160;dp outline stroke, except for illustrations that appear on colored backgrounds.</li>
 					</ul>
-					<p>Illustrations must adhere to the colors outlined in this Style Guide, however no illustrations should use Base0. As a general recommendation, an illustration should utilize no more than 3 accent or supplementary colors (eg. Blue50, Red50, Green50 and Yellow50) to avoid visual complexity. Additionally, special care should be taken when using reds with greens or blues in the same composition. Users with red-green color blindness may have difficulty differentiating between red and green elements, especially if they are overlapping. Red and blue elements should also be treated with care so as to avoid the visual illusion of <a target="_blank" href="https://en.wikipedia.org/wiki/Chromostereopsis"> chromostereopsis </a>. Illustrations may include transparent elements or cut outs, however all elements should be shown as either 0 or 100% opacity.</p>
+					<p>Illustrations must adhere to the colors outlined in this Style Guide, however no illustrations should use Base0. As a general recommendation, an illustration should utilize no more than 3 accent or supplementary colors (eg. Blue50, Red50, Green50 and Yellow50) to avoid visual complexity. Additionally, special care should be taken when using reds with greens or blues in the same composition. Users with red-green color blindness may have difficulty differentiating between red and green elements, especially if they are overlapping. Red and blue elements should also be treated with care so as to avoid the visual illusion of <a href="https://en.wikipedia.org/wiki/Chromostereopsis" target="_blank" rel="noopener">chromostereopsis </a>. Illustrations may include transparent elements or cut outs, however all elements should be shown as either 0 or 100% opacity.</p>
 				</main>
 			</div>
 		</div>
@@ -97,7 +97,7 @@
 				<li><a href="https://twitter.com/@WikimediaUX" title="Follow Wikimedia User Experience team account on Twitter">Follow @WikimediaUX</a></li>
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
-			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
+			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
 			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project">A Wikimedia Foundation project</a></p>
 		</div>
 	</footer>

--- a/visual-style_imagery.html
+++ b/visual-style_imagery.html
@@ -86,7 +86,7 @@
 				<li><a href="https://twitter.com/@WikimediaUX" title="Follow Wikimedia User Experience team account on Twitter">Follow @WikimediaUX</a></li>
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
-			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
+			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
 			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project">A Wikimedia Foundation project</a></p>
 		</div>
 	</footer>

--- a/visual-style_typography.html
+++ b/visual-style_typography.html
@@ -145,7 +145,7 @@
 				<li><a href="https://twitter.com/@WikimediaUX" title="Follow Wikimedia User Experience team account on Twitter">Follow @WikimediaUX</a></li>
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
-			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
+			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
 			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project">A Wikimedia Foundation project</a></p>
 		</div>
 	</footer>


### PR DESCRIPTION
`rel="noopener"` prevents pages from abusing window.opener, see
https://mathiasbynens.github.io/rel-noopener/

Bug: [T188698](https://phabricator.wikimedia.org/T188698)