### PR TITLE
Update URL to Wikimedia Foundation website

### DIFF
--- a/design-principles.html
+++ b/design-principles.html
@@ -144,8 +144,8 @@
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
 			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener" property="license">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
-			<p><a href="https://wikimediafoundation.org/wiki/Privacy_policy">Privacy policy</a></p>
-			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
+			<p><a href="https://foundation.wikimedia.org/wiki/Privacy_policy">Privacy policy</a></p>
+			<p><a href="https://foundation.wikimedia.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
 			<noscript><p><img src="https://piwik.wikimedia.org/piwik.php?idsite=16&rec=1" alt=""></p></noscript>
 		</div>
 	</footer>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
 					<h2 class="page__title">Introduction</h2>
 					<p>The Wikimedia Design Style Guide ensures a consistent look and behavior for our products. Its guidelines enable interactions between our diverse communities and users. </p>
 					<p>The style guide features unique focus areas like accessibility, internationalization, and localization. </p>
-					<p>Its guidelines aim to help designers and developers with their <a href="https://www.wikimedia.org/" target="_blank" rel="noopener">Wikimedia</a> projects, as part of the <a href="https://wikimediafoundation.org/" target="_blank" rel="noopener" title="Wikimedia Foundation website">Foundation</a> or in a volunteer capacity. </p>
+					<p>Its guidelines aim to help designers and developers with their <a href="https://www.wikimedia.org/" target="_blank" rel="noopener">Wikimedia</a> projects, as part of the <a href="https://foundation.wikimedia.org/" target="_blank" rel="noopener" title="Wikimedia Foundation website">Foundation</a> or in a volunteer capacity. </p>
 					<p>Our interfaces are our brand. Our visual design principles drive the aesthetics of our products. </p>
 					<section id="process">
 						<h2>Our Process</h2>
@@ -111,8 +111,8 @@
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
 			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener" property="license">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
-			<p><a href="https://wikimediafoundation.org/wiki/Privacy_policy">Privacy policy</a></p>
-			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
+			<p><a href="https://foundation.wikimedia.org/wiki/Privacy_policy">Privacy policy</a></p>
+			<p><a href="https://foundation.wikimedia.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
 			<noscript><p><img src="https://piwik.wikimedia.org/piwik.php?idsite=16&rec=1" alt=""></p></noscript>
 		</div>
 	</footer>

--- a/visual-style.html
+++ b/visual-style.html
@@ -121,8 +121,8 @@
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
 			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener" property="license">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
-			<p><a href="https://wikimediafoundation.org/wiki/Privacy_policy">Privacy policy</a></p>
-			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
+			<p><a href="https://foundation.wikimedia.org/wiki/Privacy_policy">Privacy policy</a></p>
+			<p><a href="https://foundation.wikimedia.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
 			<noscript><p><img src="https://piwik.wikimedia.org/piwik.php?idsite=16&rec=1" alt=""></p></noscript>
 		</div>
 	</footer>

--- a/visual-style_colors.html
+++ b/visual-style_colors.html
@@ -361,8 +361,8 @@
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
 			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener" property="license">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
-			<p><a href="https://wikimediafoundation.org/wiki/Privacy_policy">Privacy policy</a></p>
-			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
+			<p><a href="https://foundation.wikimedia.org/wiki/Privacy_policy">Privacy policy</a></p>
+			<p><a href="https://foundation.wikimedia.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
 			<noscript><p><img src="https://piwik.wikimedia.org/piwik.php?idsite=16&rec=1" alt=""></p></noscript>
 		</div>
 	</footer>

--- a/visual-style_icons.html
+++ b/visual-style_icons.html
@@ -155,8 +155,8 @@
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
 			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener" property="license">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
-			<p><a href="https://wikimediafoundation.org/wiki/Privacy_policy">Privacy policy</a></p>
-			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
+			<p><a href="https://foundation.wikimedia.org/wiki/Privacy_policy">Privacy policy</a></p>
+			<p><a href="https://foundation.wikimedia.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
 			<noscript><p><img src="https://piwik.wikimedia.org/piwik.php?idsite=16&rec=1" alt=""></p></noscript>
 		</div>
 	</footer>

--- a/visual-style_illustrations.html
+++ b/visual-style_illustrations.html
@@ -123,8 +123,8 @@
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
 			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener" property="license">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
-			<p><a href="https://wikimediafoundation.org/wiki/Privacy_policy">Privacy policy</a></p>
-			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
+			<p><a href="https://foundation.wikimedia.org/wiki/Privacy_policy">Privacy policy</a></p>
+			<p><a href="https://foundation.wikimedia.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
 			<noscript><p><img src="https://piwik.wikimedia.org/piwik.php?idsite=16&rec=1" alt=""></p></noscript>
 		</div>
 	</footer>

--- a/visual-style_images.html
+++ b/visual-style_images.html
@@ -102,8 +102,8 @@
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
 			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener" property="license">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
-			<p><a href="https://wikimediafoundation.org/wiki/Privacy_policy">Privacy policy</a></p>
-			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
+			<p><a href="https://foundation.wikimedia.org/wiki/Privacy_policy">Privacy policy</a></p>
+			<p><a href="https://foundation.wikimedia.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
 			<noscript><p><img src="https://piwik.wikimedia.org/piwik.php?idsite=16&rec=1" alt=""></p></noscript>
 		</div>
 	</footer>

--- a/visual-style_typography.html
+++ b/visual-style_typography.html
@@ -171,8 +171,8 @@
 				<li><a href="https://lists.wikimedia.org/mailman/listinfo/design" title="Join Wikimedia Design mailing list">Join mailing list</a></li>
 			</ul>
 			<p>Text is available under the <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noopener" property="license">Creative Commons Attribution-ShareAlike 4.0 International</a>, additional terms may apply. <br>Code is available under the MIT license.</p>
-			<p><a href="https://wikimediafoundation.org/wiki/Privacy_policy">Privacy policy</a></p>
-			<p><a href="https://wikimediafoundation.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
+			<p><a href="https://foundation.wikimedia.org/wiki/Privacy_policy">Privacy policy</a></p>
+			<p><a href="https://foundation.wikimedia.org/" class="lnk--wikimedia-project" property="author" typeof="Organization">A Wikimedia Foundation project</a></p>
 			<noscript><p><img src="https://piwik.wikimedia.org/piwik.php?idsite=16&rec=1" alt=""></p></noscript>
 		</div>
 	</footer>


### PR DESCRIPTION
It used to be wikimediafoundation.org but now it's foundation.wikimedia.org