### PR TITLE
Visual Style: Add `section` elements and jump marker ids

### DIFF
--- a/visual-style_colors.html
+++ b/visual-style_colors.html
@@ -170,185 +170,193 @@
 
 					<p>Because content readability for everyone is our main goal, we have made accessibility considerations a top priority. Each color detailed  below indicates its <a href="https://www.w3.org/WAI/intro/wcag" target="_blank" rel="noopener" title="Web Content Accessibility Guidelines 2.0">WCAG</a> conformance level (“AA” or “AAA”). This level is based on a color's contrast against white or black.</p>
 
-					<h2>Base colors</h2>
-					<p>Base colors define the content surface and the main color for content. Different shades of paper and ink are useful to emphasize or de-emphasize different content areas.</p>
-					<p>Base colors range from pure white (Base100) to true black (Base0). Intermediate shades of gray include a tint of blue for greater harmony with our accent colors.</p>
-					<p>When applying text on a surface, you need to <a href="http://webaim.org/resources/contrastchecker/" target="_blank" rel="noopener">check the color contrast</a> between the text and the background: </p>
-					<ul>
-						<li>Base100…50 are safe text colors for a black surface.</li>
-						<li>Base30…0 are safe text colors for a white surface. </li>
-					</ul>
-					<ol class="color-palette color-section">
-						<li class="color" style="background-color: #fff; border-color: #eaecf0;">
-							<strong class="color__name">Base100</strong>
-							<code class="color-code color-code--hex">#fff</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 255, 255, 255</code>
-							<code class="color-code color-code--hsb">HSB 0, 0%, 100%</code>
-						</li>
-						<li class="color" style="background-color: #f8f9fa;">
-							<strong class="color__name">Base90</strong>
-							<code class="color-code color-code--hex">#f8f9fa</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 248, 249, 250</code>
-							<code class="color-code color-code--hsb">HSB 210, 1%, 98%</code>
-						</li>
-						<li class="color" style="background-color: #eaecf0;">
-							<strong class="color__name">Base80</strong>
-							<code class="color-code color-code--hex">#eaecf0</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 234, 236, 240</code>
-							<code class="color-code color-code--hsb">HSB 220, 3%, 94%</code>
-						</li>
-						<li class="color" style="background-color: #c8ccd1;">
-							<strong class="color__name">Base70</strong>
-							<code class="color-code color-code--hex">#c8ccd1</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 200, 204, 209</code>
-							<code class="color-code color-code--hsb">HSB 213, 4%, 82%</code>
-						</li>
-						<li class="color" style="background-color: #a2a9b1;">
-							<strong class="color__name">Base50</strong>
-							<code class="color-code color-code--hex">#a2a9b1</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 162, 169, 177</code>
-							<code class="color-code color-code--hsb">HSB 212, 8%, 69%</code>
-						</li>
-						<li class="color" style="background-color: #72777d;">
-							<strong class="color__name">Base30</strong>
-							<code class="color-code color-code--hex">#72777d</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AA / <span>AA</span></span>
-							<code class="color-code color-code--rgb">RGB 114, 119, 125</code>
-							<code class="color-code color-code--hsb">HSB 210, 9%, 49%</code>
-						</li>
-						<li class="color color--dark" style="background-color: #54595d;">
-							<strong class="color__name">Base20</strong>
-							<code class="color-code color-code--hex">#54595d</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 84, 89, 93</code>
-							<code class="color-code color-code--hsb">HSB 207, 10%, 36%</code>
-						</li>
-						<li class="color color--dark" style="background-color: #222;">
-							<strong class="color__name">Base10</strong>
-							<code class="color-code color-code--hex">#222</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 34, 34, 34</code>
-							<code class="color-code color-code--hsb">HSB 0, 0%, 13%</code>
-						</li>
-						<li class="color color--dark" style="background-color: #000;">
-							<strong class="color__name">Base0</strong>
-							<code class="color-code color-code--hex">#000</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 0, 0, 0</code>
-							<code class="color-code color-code--hsb">HSB 0, 0%, 0%</code>
-						</li>
-					</ol>
-
-					<h2>Accent colors</h2>
-					<p>Accent colors are used to emphasize actions and to highlight key information. Blue is a natural choice in our context, where it has been the default color used for links and conveys the idea of action.</p>
-					<p>There are three shades provided for when you need a lighter (Accent90), regular (Accent50) or a darker (Accent10) version of blue.</p>
-					<p>Accent50 is suitable to use for text and as background. When used for link text, this color provides sufficient contrast with black text. When used as background, it provides sufficient contrast with white text.</p>
+					<section id="base-colors">
+						<h2>Base colors</h2>
+						<p>Base colors define the content surface and the main color for content. Different shades of paper and ink are useful to emphasize or de-emphasize different content areas.</p>
+						<p>Base colors range from pure white (Base100) to true black (Base0). Intermediate shades of gray include a tint of blue for greater harmony with our accent colors.</p>
+						<p>When applying text on a surface, you need to <a href="http://webaim.org/resources/contrastchecker/" target="_blank" rel="noopener">check the color contrast</a> between the text and the background: </p>
+						<ul>
+							<li>Base100…50 are safe text colors for a black surface.</li>
+							<li>Base30…0 are safe text colors for a white surface. </li>
+						</ul>
 						<ol class="color-palette color-section">
-						<li class="color" style="background-color: #eaf3ff;">
-							<strong class="color__name"><span>Accent</span>90</strong>
-							<code class="color-code color-code--hex">#eaf3ff</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 234, 243, 255</code>
-							<code class="color-code color-code--hsb">HSB 214, 8%, 100%</code>
-						</li>
-						<li class="color color--dark" style="background-color: #36c;">
-							<strong class="color__name"><span>Accent</span>50</strong>
-							<code class="color-code color-code--hex">#36c</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AA</span>
-							<span class="color__type">Progressive</span>
-							<code class="color-code color-code--rgb">RGB 51, 102, 204</code>
-							<code class="color-code color-code--hsb">HSB 220, 75%, 80%</code>
-						</li>
-						<li class="color color--dark" style="background-color: #2a4b8d;">
-							<strong class="color__name"><span>Accent</span>10</strong>
-							<code class="color-code color-code--hex">#2a4b8d</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 42, 75, 141</code>
-							<code class="color-code color-code--hsb">HSB 220, 70%, 55%</code>
-						</li>
-					</ol>
+							<li class="color" style="background-color: #fff; border-color: #eaecf0;">
+								<strong class="color__name">Base100</strong>
+								<code class="color-code color-code--hex">#fff</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 255, 255, 255</code>
+								<code class="color-code color-code--hsb">HSB 0, 0%, 100%</code>
+							</li>
+							<li class="color" style="background-color: #f8f9fa;">
+								<strong class="color__name">Base90</strong>
+								<code class="color-code color-code--hex">#f8f9fa</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 248, 249, 250</code>
+								<code class="color-code color-code--hsb">HSB 210, 1%, 98%</code>
+							</li>
+							<li class="color" style="background-color: #eaecf0;">
+								<strong class="color__name">Base80</strong>
+								<code class="color-code color-code--hex">#eaecf0</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 234, 236, 240</code>
+								<code class="color-code color-code--hsb">HSB 220, 3%, 94%</code>
+							</li>
+							<li class="color" style="background-color: #c8ccd1;">
+								<strong class="color__name">Base70</strong>
+								<code class="color-code color-code--hex">#c8ccd1</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 200, 204, 209</code>
+								<code class="color-code color-code--hsb">HSB 213, 4%, 82%</code>
+							</li>
+							<li class="color" style="background-color: #a2a9b1;">
+								<strong class="color__name">Base50</strong>
+								<code class="color-code color-code--hex">#a2a9b1</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 162, 169, 177</code>
+								<code class="color-code color-code--hsb">HSB 212, 8%, 69%</code>
+							</li>
+							<li class="color" style="background-color: #72777d;">
+								<strong class="color__name">Base30</strong>
+								<code class="color-code color-code--hex">#72777d</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AA / <span>AA</span></span>
+								<code class="color-code color-code--rgb">RGB 114, 119, 125</code>
+								<code class="color-code color-code--hsb">HSB 210, 9%, 49%</code>
+							</li>
+							<li class="color color--dark" style="background-color: #54595d;">
+								<strong class="color__name">Base20</strong>
+								<code class="color-code color-code--hex">#54595d</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 84, 89, 93</code>
+								<code class="color-code color-code--hsb">HSB 207, 10%, 36%</code>
+							</li>
+							<li class="color color--dark" style="background-color: #222;">
+								<strong class="color__name">Base10</strong>
+								<code class="color-code color-code--hex">#222</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 34, 34, 34</code>
+								<code class="color-code color-code--hsb">HSB 0, 0%, 13%</code>
+							</li>
+							<li class="color color--dark" style="background-color: #000;">
+								<strong class="color__name">Base0</strong>
+								<code class="color-code color-code--hex">#000</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 0, 0, 0</code>
+								<code class="color-code color-code--hsb">HSB 0, 0%, 0%</code>
+							</li>
+						</ol>
+					</section>
 
-					<h2>Utility colors</h2>
-					<p>Utility colors are another type of accent color. Common meanings are associated with them.</p>
-					<p>We use shades of red, green, and yellow as utility colors.</p>
-					<ol class="color-palette color-section">
-						<li class="color" style="background-color: #fee7e6;">
-							<strong class="color__name">Red90</strong>
-							<code class="color-code color-code--hex">#fee7e6</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 255, 231, 230</code>
-							<code class="color-code color-code--hsb">HSB 2, 10%, 100%</code>
-						</li>
-						<li class="color color--dark" style="background-color: #d33;">
-							<strong class="color__name">Red50</strong>
-							<code class="color-code color-code--hex">#d33</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AA / <span>AA</span></span>
-							<span class="color__type">Destructive</span>
-							<code class="color-code color-code--rgb">RGB 221, 51, 51</code>
-							<code class="color-code color-code--hsb">HSB 360, 77%, 87%</code>
-						</li>
-						<li class="color color--dark" style="background-color: #b32424;">
-							<strong class="color__name">Red30</strong>
-							<code class="color-code color-code--hex">#b32424</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 135, 54, 54</code>
-							<code class="color-code color-code--hsb">HSB 360, 60%, 53%</code>
-						</li>
-					</ol>
-					<ol class="color-palette color-section">
-						<li class="color" style="background-color: #d5fdf4;">
-							<strong class="color__name">Green90</strong>
-							<code class="color-code color-code--hex">#d5fdf4</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 213, 253, 244</code>
-							<code class="color-code color-code--hsb">HSB 167, 16%, 99%</code>
-						</li>
-						<li class="color" style="background-color: #00af89;">
-							<strong class="color__name">Green50</strong>
-							<code class="color-code color-code--hex">#00af89</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AA</span>
-							<code class="color-code color-code--rgb">RGB 0, 175, 137</code>
-							<code class="color-code color-code--hsb">HSB 167, 100%, 69%</code>
-						</li>
-						<li class="color color--dark" style="background-color: #14866d;">
-							<strong class="color__name">Green30</strong>
-							<code class="color-code color-code--hex">#14866d</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AA</span>
-							<code class="color-code color-code--rgb">RGB 20, 134, 109</code>
-							<code class="color-code color-code--hsb">HSB 167, 85%, 53%</code>
-						</li>
-					</ol>
-					<ol class="color-palette color-section">
-						<li class="color" style="background-color: #fef6e7;">
-							<strong class="color__name">Yellow90</strong>
-							<code class="color-code color-code--hex">#fef6e7</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 254, 246, 231</code>
-							<code class="color-code color-code--hsb">HSB 39, 9%, 100%</code>
-						</li>
-						<li class="color" style="background-color: #fc3;">
-							<strong class="color__name">Yellow50</strong>
-							<code class="color-code color-code--hex">#fc3</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
-							<code class="color-code color-code--rgb">RGB 255, 204, 51</code>
-							<code class="color-code color-code--hsb">HSB 45, 80%, 100%</code>
-						</li>
-						<li class="color color--dark" style="background-color: #ac6600;">
-							<strong class="color__name">Yellow30</strong>
-							<code class="color-code color-code--hex">#ac6600</code>
-							<span class="color__wcag-level" title="WCAG conformance level">AA</span>
-							<code class="color-code color-code--rgb">RGB 172, 102, 0</code>
-							<code class="color-code color-code--hsb">HSB 36, 100%, 67%</code>
-						</li>
-					</ol>
+					<section id="accent-colors">
+						<h2>Accent colors</h2>
+						<p>Accent colors are used to emphasize actions and to highlight key information. Blue is a natural choice in our context, where it has been the default color used for links and conveys the idea of action.</p>
+						<p>There are three shades provided for when you need a lighter (Accent90), regular (Accent50) or a darker (Accent10) version of blue.</p>
+						<p>Accent50 is suitable to use for text and as background. When used for link text, this color provides sufficient contrast with black text. When used as background, it provides sufficient contrast with white text.</p>
+							<ol class="color-palette color-section">
+							<li class="color" style="background-color: #eaf3ff;">
+								<strong class="color__name"><span>Accent</span>90</strong>
+								<code class="color-code color-code--hex">#eaf3ff</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 234, 243, 255</code>
+								<code class="color-code color-code--hsb">HSB 214, 8%, 100%</code>
+							</li>
+							<li class="color color--dark" style="background-color: #36c;">
+								<strong class="color__name"><span>Accent</span>50</strong>
+								<code class="color-code color-code--hex">#36c</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AA</span>
+								<span class="color__type">Progressive</span>
+								<code class="color-code color-code--rgb">RGB 51, 102, 204</code>
+								<code class="color-code color-code--hsb">HSB 220, 75%, 80%</code>
+							</li>
+							<li class="color color--dark" style="background-color: #2a4b8d;">
+								<strong class="color__name"><span>Accent</span>10</strong>
+								<code class="color-code color-code--hex">#2a4b8d</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 42, 75, 141</code>
+								<code class="color-code color-code--hsb">HSB 220, 70%, 55%</code>
+							</li>
+						</ol>
+					</section>
 
-					<h2>Additional colors</h2>
-					<p>Some use cases, such as charts and data visualization, may need a broader color palette. Aim for level AA contrast (4.5:1) when extending the default palette. Make sure to test how these colors are perceived at different color vision deficiency conditions.</p>
+					<section id="utility-colors">
+						<h2>Utility colors</h2>
+						<p>Utility colors are another type of accent color. Common meanings are associated with them.</p>
+						<p>We use shades of red, green, and yellow as utility colors.</p>
+						<ol class="color-palette color-section">
+							<li class="color" style="background-color: #fee7e6;">
+								<strong class="color__name">Red90</strong>
+								<code class="color-code color-code--hex">#fee7e6</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 255, 231, 230</code>
+								<code class="color-code color-code--hsb">HSB 2, 10%, 100%</code>
+							</li>
+							<li class="color color--dark" style="background-color: #d33;">
+								<strong class="color__name">Red50</strong>
+								<code class="color-code color-code--hex">#d33</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AA / <span>AA</span></span>
+								<span class="color__type">Destructive</span>
+								<code class="color-code color-code--rgb">RGB 221, 51, 51</code>
+								<code class="color-code color-code--hsb">HSB 360, 77%, 87%</code>
+							</li>
+							<li class="color color--dark" style="background-color: #b32424;">
+								<strong class="color__name">Red30</strong>
+								<code class="color-code color-code--hex">#b32424</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 135, 54, 54</code>
+								<code class="color-code color-code--hsb">HSB 360, 60%, 53%</code>
+							</li>
+						</ol>
+						<ol class="color-palette color-section">
+							<li class="color" style="background-color: #d5fdf4;">
+								<strong class="color__name">Green90</strong>
+								<code class="color-code color-code--hex">#d5fdf4</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 213, 253, 244</code>
+								<code class="color-code color-code--hsb">HSB 167, 16%, 99%</code>
+							</li>
+							<li class="color" style="background-color: #00af89;">
+								<strong class="color__name">Green50</strong>
+								<code class="color-code color-code--hex">#00af89</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AA</span>
+								<code class="color-code color-code--rgb">RGB 0, 175, 137</code>
+								<code class="color-code color-code--hsb">HSB 167, 100%, 69%</code>
+							</li>
+							<li class="color color--dark" style="background-color: #14866d;">
+								<strong class="color__name">Green30</strong>
+								<code class="color-code color-code--hex">#14866d</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AA</span>
+								<code class="color-code color-code--rgb">RGB 20, 134, 109</code>
+								<code class="color-code color-code--hsb">HSB 167, 85%, 53%</code>
+							</li>
+						</ol>
+						<ol class="color-palette color-section">
+							<li class="color" style="background-color: #fef6e7;">
+								<strong class="color__name">Yellow90</strong>
+								<code class="color-code color-code--hex">#fef6e7</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 254, 246, 231</code>
+								<code class="color-code color-code--hsb">HSB 39, 9%, 100%</code>
+							</li>
+							<li class="color" style="background-color: #fc3;">
+								<strong class="color__name">Yellow50</strong>
+								<code class="color-code color-code--hex">#fc3</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
+								<code class="color-code color-code--rgb">RGB 255, 204, 51</code>
+								<code class="color-code color-code--hsb">HSB 45, 80%, 100%</code>
+							</li>
+							<li class="color color--dark" style="background-color: #ac6600;">
+								<strong class="color__name">Yellow30</strong>
+								<code class="color-code color-code--hex">#ac6600</code>
+								<span class="color__wcag-level" title="WCAG conformance level">AA</span>
+								<code class="color-code color-code--rgb">RGB 172, 102, 0</code>
+								<code class="color-code color-code--hsb">HSB 36, 100%, 67%</code>
+							</li>
+						</ol>
+					</section>
+
+					<section id="additional-colors">
+						<h2>Additional colors</h2>
+						<p>Some use cases, such as charts and data visualization, may need a broader color palette. Aim for level AA contrast (4.5:1) when extending the default palette. Make sure to test how these colors are perceived at different color vision deficiency conditions.</p>
+					</section>
 				</main>
 			</div>
 		</div>

--- a/visual-style_icons.html
+++ b/visual-style_icons.html
@@ -85,64 +85,76 @@
 						<img src="img/visual-style/icons-sample.svg" onerror="this.src='img/visual-style/icons-sample.png'" alt="Sample of WikimediaUI icons" role="img">
 					</figure>
 
-					<h2>Principles</h2>
-					<p>Wikimedia icons should be simple and neutral. <sup><a href="#References">[1]</a></sup></p>
-					<p><strong>Reduce to the essential form</strong> <br>
-						Use fewer details to convey the icon in as simple a shape as possible. The core idea of the design should be clearly conveyed and should remain discernible even at smaller sizes. For example, a keyboard should <i>not</i> be represented by showing all 100+ keys that are in the real object, since this would make it unrecognizable. </p>
-					<p><strong>Universal rather than culturally-specific</strong> <br>
-						Symbols and ideas represented in iconography should be known to a global audience. For example, do not use a dollar sign “$” to represent money, or a four-leaf clover to represent luck.</p>
-					<p><strong>Avoid textual content within the icon</strong> <br>
-						Besides loss of universal recognition when including a specific language element, it may add unnecessary complexity. There are exceptions for icons related to language/text (for example, the icon for language switching).</p>
-					<p><strong>Abstract forms or concrete objects</strong> <br>
-						Take consideration when deciding to use abstract or concrete objects when designing an icon. In some cases, concrete objects are preferred, such as using dice to convey “random” or a bell to convey an alert. In other cases, abstract symbols may be preferable, such as using an question mark “?” for help rather than a life preserver, or an ellipsis “…” to indicate “more”.</p>
-					<p><strong>Neutral point of view</strong> <br>
-						Avoid concepts such as gestures, animals, religion, humor, ethnicity, and gender.</p>
+					<section id="principles">
+						<h2>Principles</h2>
+						<p>Wikimedia icons should be simple and neutral. <sup><a href="#References">[1]</a></sup></p>
+						<p><strong>Reduce to the essential form</strong> <br>
+							Use fewer details to convey the icon in as simple a shape as possible. The core idea of the design should be clearly conveyed and should remain discernible even at smaller sizes. For example, a keyboard should <i>not</i> be represented by showing all 100+ keys that are in the real object, since this would make it unrecognizable. </p>
+						<p><strong>Universal rather than culturally-specific</strong> <br>
+							Symbols and ideas represented in iconography should be known to a global audience. For example, do not use a dollar sign “$” to represent money, or a four-leaf clover to represent luck.</p>
+						<p><strong>Avoid textual content within the icon</strong> <br>
+							Besides loss of universal recognition when including a specific language element, it may add unnecessary complexity. There are exceptions for icons related to language/text (for example, the icon for language switching).</p>
+						<p><strong>Abstract forms or concrete objects</strong> <br>
+							Take consideration when deciding to use abstract or concrete objects when designing an icon. In some cases, concrete objects are preferred, such as using dice to convey “random” or a bell to convey an alert. In other cases, abstract symbols may be preferable, such as using an question mark “?” for help rather than a life preserver, or an ellipsis “…” to indicate “more”.</p>
+						<p><strong>Neutral point of view</strong> <br>
+							Avoid concepts such as gestures, animals, religion, humor, ethnicity, and gender.</p>
+					</section>
 
-					<h2>Visual style</h2>
-					<p>Characteristics of a WikimediaUI icon:</p>
-					<ul>
-						<li><strong>Monochromatic.</strong> Solid color icons.</li>
-						<li><strong>Geometric.</strong> Comprised of simple and symmetrical geometric shapes. Symmetrical icons tend to be more universally applicable. For example, an open book would be prefered to a closed book with binding on left or right side). </li>
-						<li><strong>Front-facing. </strong>Icons are flat and front facing, not multi-dimensional.</li>
-						<li><strong>20 x 20&#160;dp default canvas.</strong> WikimediaUI icons are put on a 20 x 20 device-independent pixel (`dp`)<sup><a href="#References">[2]</a></sup> canvas per default.</li>
-						<li><strong>Rounded corners.</strong> Corners are rounded to make shapes friendly and welcoming. For the default canvas use 2&#160;dp rounded corners. Note that rounded corners are applied only on the exterior of an icon shape, not interior corners.</li>
-						<li><strong>Medium thick stroke.</strong> Lines and outline should be visible at smaller sizes without effort, for the default icon canvas use a 2&#160;dp thick stroke as standard. Endpoints of lines are square in keeping with simple geometric shapes.</li>
-						<li><strong>Diagonal cross-out lines.</strong> For icons that appear to be crossed-out, the cross-out line starts from the top-left of the icon and continues at a 45 degree angle to the bottom right (similar to a backslash “\”).</li>
-					</ul>
+					<section id="visual-style">
+						<h2>Visual style</h2>
+						<p>Characteristics of a WikimediaUI icon:</p>
+						<ul>
+							<li><strong>Monochromatic.</strong> Solid color icons.</li>
+							<li><strong>Geometric.</strong> Comprised of simple and symmetrical geometric shapes. Symmetrical icons tend to be more universally applicable. For example, an open book would be prefered to a closed book with binding on left or right side). </li>
+							<li><strong>Front-facing. </strong>Icons are flat and front facing, not multi-dimensional.</li>
+							<li><strong>20 x 20&#160;dp default canvas.</strong> WikimediaUI icons are put on a 20 x 20 device-independent pixel (`dp`)<sup><a href="#References">[2]</a></sup> canvas per default.</li>
+							<li><strong>Rounded corners.</strong> Corners are rounded to make shapes friendly and welcoming. For the default canvas use 2&#160;dp rounded corners. Note that rounded corners are applied only on the exterior of an icon shape, not interior corners.</li>
+							<li><strong>Medium thick stroke.</strong> Lines and outline should be visible at smaller sizes without effort, for the default icon canvas use a 2&#160;dp thick stroke as standard. Endpoints of lines are square in keeping with simple geometric shapes.</li>
+							<li><strong>Diagonal cross-out lines.</strong> For icons that appear to be crossed-out, the cross-out line starts from the top-left of the icon and continues at a 45 degree angle to the bottom right (similar to a backslash “\”).</li>
+						</ul>
+					</section>
 
-					<h2>Guidelines for creating icons</h2>
-					<figure class="figure figure--full">
-						<figcaption>Icons follow a template. The default canvas is 20 x 20&#160;dp. In order to allow for optical adjustments, a different margin is applied depending on the shape of the icon.</figcaption>
-						<img src="img/visual-style/icons-optical-adjustment.svg" onerror="this.src='img/visual-style/icons-optical-adjustment.png'" alt="Icon sizes at different shapes for optical adjustment" role="img">
-					</figure>
-					<p>Different shapes have different perceived sizes. A 1&#160;dp margin for square-shaped icon is used. A circle uses the full 20 x 20&#160;dp canvas available to reach a similar perceived size.</p>
-					<p><strong>Black icons</strong> <br>
-						Use black (<a href="visual-style_colors.html">Base0</a>) on a transparent background, as the boldest representation of an icon. The color can be changed when the icon is used (preferably done automatically by software).</p>
-					<p><strong>Filled areas with no stroke outlines</strong> <br>
-						For example, a donut icon is a filled circle with a hole in the middle, as opposed to an unfilled circle with a thick stroke outline.</p>
-					<p><strong>Pixel-fitting</strong> <br>
-						Ensure icon shape edges are fit to pixels as closely as possible, so that shapes are not distorted or fuzzy.</p>
-					<p><strong>Right-to-left (RTL) and left-to-right (LTR) considerations</strong> <br>
-						In cases where the icon is non-symmetrical, consider whether RTL or LTR directionality changes the meaning conveyed before creating the alternate direction variation. For example, the play button is universally seen as a triangle with a straight left edge and does not require two variations, whilst a bullet list icon would show the “bullets” in the list on the right or left side depending on whether it is shown in RTL or LTR language context.</p>
+					<section id="creating-icons">
+						<h2>Creating icons</h2>
+						<figure class="figure figure--full">
+							<figcaption>Icons follow a template. The default canvas is 20 x 20&#160;dp. In order to allow for optical adjustments, a different margin is applied depending on the shape of the icon.</figcaption>
+							<img src="img/visual-style/icons-optical-adjustment.svg" onerror="this.src='img/visual-style/icons-optical-adjustment.png'" alt="Icon sizes at different shapes for optical adjustment" role="img">
+						</figure>
+						<p>Different shapes have different perceived sizes. A 1&#160;dp margin for square-shaped icon is used. A circle uses the full 20 x 20&#160;dp canvas available to reach a similar perceived size.</p>
+						<p><strong>Black icons</strong> <br>
+							Use black (<a href="visual-style_colors.html">Base0</a>) on a transparent background, as the boldest representation of an icon. The color can be changed when the icon is used (preferably done automatically by software).</p>
+						<p><strong>Filled areas with no stroke outlines</strong> <br>
+							For example, a donut icon is a filled circle with a hole in the middle, as opposed to an unfilled circle with a thick stroke outline.</p>
+						<p><strong>Pixel-fitting</strong> <br>
+							Ensure icon shape edges are fit to pixels as closely as possible, so that shapes are not distorted or fuzzy.</p>
+						<p><strong>Right-to-left (RTL) and left-to-right (LTR) considerations</strong> <br>
+							In cases where the icon is non-symmetrical, consider whether RTL or LTR directionality changes the meaning conveyed before creating the alternate direction variation. For example, the play button is universally seen as a triangle with a straight left edge and does not require two variations, whilst a bullet list icon would show the “bullets” in the list on the right or left side depending on whether it is shown in RTL or LTR language context.</p>
+					</section>
 
-					<h2>Usage</h2>
-					<p><strong>Clearance on touch devices</strong><br>
-						When using icons consider the size of their target area. Even if icons are presented at a smaller size, make sure that the associated active area is at least 44 x 44&#160;dp. Otherwise users may fail to hit the active area and not encounter the expected result.</p>
+					<section id="usage">
+						<h2>Usage</h2>
+						<p><strong>Clearance on touch devices</strong><br>
+							When using icons consider the size of their target area. Even if icons are presented at a smaller size, make sure that the associated active area is at least 44 x 44&#160;dp. Otherwise users may fail to hit the active area and not encounter the expected result.</p>
 
-					<p><strong>Adapt and remix</strong><br>
-						Our icons are freely licensed under CC BY 4.0. <br>
-						The simple style and guidelines make it easy to reuse or adapt existing freely licensed icons that you can find on other repos such as <a href="https://material.io/icons/" target="_blank" rel="noopener">Material icons</a> <sup><a href="#References">[3]</a></sup> or the <a href="https://thenounproject.com/" target="_blank" rel="noopener">Noun project</a> <sup><a href="#References">[4]</a></sup>. You are welcome to use existing icons that align to the proposed style instead of reinventing the wheel icon.</p>
+						<p><strong>Adapt and remix</strong><br>
+							Our icons are freely licensed under CC BY 4.0. <br>
+							The simple style and guidelines make it easy to reuse or adapt existing freely licensed icons that you can find on other repos such as <a href="https://material.io/icons/" target="_blank" rel="noopener">Material icons</a> <sup><a href="#References">[3]</a></sup> or the <a href="https://thenounproject.com/" target="_blank" rel="noopener">Noun project</a> <sup><a href="#References">[4]</a></sup>. You are welcome to use existing icons that align to the proposed style instead of reinventing the wheel icon.</p>
+					</section>
 
-					<h2>Resources</h2>
-					<p>The <a href="https://doc.wikimedia.org/oojs-ui/master/demos/?page=icons&theme=wikimediaui&direction=ltr&platform=desktop#icons-mediawiki-ltr">OOUI icon repository</a> provides a list of the currently available icons.</p>
+					<section id="resources">
+						<h2>Resources</h2>
+						<p>The <a href="https://doc.wikimedia.org/oojs-ui/master/demos/?page=icons&theme=wikimediaui&direction=ltr&platform=desktop#icons-mediawiki-ltr">OOUI icon repository</a> provides a list of the currently available icons.</p>
+					</section>
 
-					<h2 id="References">References</h2>
-					<ol>
-						<li>Thanks to volunteer contributor <a href="https://phabricator.wikimedia.org/p/SamanthaNguyen/" target="_blank" rel="noopener">@SamanthaNguyen</a> for many suggestions on the “Principles” section in icons on <a href="https://phabricator.wikimedia.org/T155684" target="_blank" rel="noopener">Phabricator task T155684</a>.</li>
-						<li>1&#160;dp equals 1&#160;px in CSS at 100% zoom level and 1x device. <a href="https://en.wikipedia.org/wiki/Device-independent_pixel" target="_blank" rel="noopener">Device-independent pixel on English Wikipedia</a>.</li>
-						<li>Google offers a <a href="https://material.io/guidelines/style/icons.html" target="_blank" rel="noopener">Material icons overview and guide to use</a>.</li>
-						<li>The Noun Project provides curated <a href="https://thenounproject.zendesk.com/hc/en-us/articles/200509798-What-licenses-do-you-use-" target="_blank" rel="noopener">icon sets that are either Creative Commons Attribution (CC BY) or Public Domain (PD)</a>.</li>
-					</ol>
+					<section id="references">
+						<h2>References</h2>
+						<ol>
+							<li>Thanks to volunteer contributor <a href="https://phabricator.wikimedia.org/p/SamanthaNguyen/" target="_blank" rel="noopener">@SamanthaNguyen</a> for many suggestions on the “Principles” section in icons on <a href="https://phabricator.wikimedia.org/T155684" target="_blank" rel="noopener">Phabricator task T155684</a>.</li>
+							<li>1&#160;dp equals 1&#160;px in CSS at 100% zoom level and 1x device. <a href="https://en.wikipedia.org/wiki/Device-independent_pixel" target="_blank" rel="noopener">Device-independent pixel on English Wikipedia</a>.</li>
+							<li>Google offers a <a href="https://material.io/guidelines/style/icons.html" target="_blank" rel="noopener">Material icons overview and guide to use</a>.</li>
+							<li>The Noun Project provides curated <a href="https://thenounproject.zendesk.com/hc/en-us/articles/200509798-What-licenses-do-you-use-" target="_blank" rel="noopener">icon sets that are either Creative Commons Attribution (CC BY) or Public Domain (PD)</a>.</li>
+						</ol>
+					</section>
 				</main>
 			</div>
 		</div>

--- a/visual-style_illustrations.html
+++ b/visual-style_illustrations.html
@@ -80,37 +80,43 @@
 					<div class="page__parent-title">Visual Style</div>
 					<h1 class="page__title">Illustrations</h1>
 
-					<h2>Illustration style</h2>
-					<img src="img/visual-style/illustrations-header.svg" onerror="this.src='img/visual-style/illustrations-header.png'" alt="Sample of four illustrations">
-					<p><strong>Colored backgrounds</strong><br>
-					Illustrations that appear on a colored background should not include an outline stroke. Elements inside of the illustration should also not contain an outline stroke. Any lines inside of the illustration should have a weight of 2&#160;dp. The illustration can utilize any of the colors available in the Style Guide excluding Base0.</p>
-					<p><strong>White background</strong><br>
-					Illustrations that appear on a white background should include a 2&#160;dp outline stroke in Base50. Elements inside of the illustration can contain an outline stroke, this stroke should also be a 2&#160;dp stroke in Base50. The illustration can utilize any of the colors available in the Style Guide excluding Base0.</p>
-					<p><strong>Grey scale</strong><br>
-					Grey scale illustrations (for use in empty states) should include a 2&#160;dp outline stroke in Base60. Elements inside of the illustration can contain an outline stroke, this stroke should also be a 2&#160;dp stroke in Base60. The illustration should only include base colors excluding Base0.</p>
+					<section id="illustration-style">
+						<h2>Illustration style</h2>
+						<img src="img/visual-style/illustrations-header.svg" onerror="this.src='img/visual-style/illustrations-header.png'" alt="Sample of four illustrations">
+						<p><strong>Colored backgrounds</strong><br>
+						Illustrations that appear on a colored background should not include an outline stroke. Elements inside of the illustration should also not contain an outline stroke. Any lines inside of the illustration should have a weight of 2&#160;dp. The illustration can utilize any of the colors available in the Style Guide excluding Base0.</p>
+						<p><strong>White background</strong><br>
+						Illustrations that appear on a white background should include a 2&#160;dp outline stroke in Base50. Elements inside of the illustration can contain an outline stroke, this stroke should also be a 2&#160;dp stroke in Base50. The illustration can utilize any of the colors available in the Style Guide excluding Base0.</p>
+						<p><strong>Grey scale</strong><br>
+						Grey scale illustrations (for use in empty states) should include a 2&#160;dp outline stroke in Base60. Elements inside of the illustration can contain an outline stroke, this stroke should also be a 2&#160;dp stroke in Base60. The illustration should only include base colors excluding Base0.</p>
+					</section>
 
-					<h2>Using illustrations</h2>
-					<img src="img/visual-style/illustrations-sample.png" onerror="this.src='img/visual-style/illustrations-header.png'" alt="Sample of three illustration styles">
-					<p>Illustrations should be used as a supporting element alongside text and should never appear alone. Illustrations should be relevant and context-aware of their surroundings, do not include illustrations simply for decoration. Empty states, onboarding, or modals containing messaging are the primary use cases for utilizing illustrations. Utilize the appropriate illustration style depending on the background that the illustration will be presented on.</p>
-					<p>Illustrations should never appear pixelated. Test the resolution of your illustration for the specific the ratios you will be using it in.</p>
+					<section id="using-illustrations">
+						<h2>Using illustrations</h2>
+						<img src="img/visual-style/illustrations-sample.png" onerror="this.src='img/visual-style/illustrations-header.png'" alt="Sample of three illustration styles">
+						<p>Illustrations should be used as a supporting element alongside text and should never appear alone. Illustrations should be relevant and context-aware of their surroundings, do not include illustrations simply for decoration. Empty states, onboarding, or modals containing messaging are the primary use cases for utilizing illustrations. Utilize the appropriate illustration style depending on the background that the illustration will be presented on.</p>
+						<p>Illustrations should never appear pixelated. Test the resolution of your illustration for the specific the ratios you will be using it in.</p>
+					</section>
 
-					<h2>Creating illustrations</h2>
-					<figure class="illustrations-case-study">
-						<img src="img/visual-style/illustrations-colored-background.svg" onerror="this.src='img/visual-style/illustrations-colored-background.png'" alt="Illustration on colored background">
-						<img src="img/visual-style/illustrations-white-background.svg" onerror="this.src='img/visual-style/illustrations-white-background.png'" alt="Illustration on white background">
-						<img src="img/visual-style/illustrations-grey-background.svg" onerror="this.src='img/visual-style/illustrations-grey-background.png'" alt="Illustration on grey background">
-						<figcaption class="figure__caption">In production case studies</figcaption>
-					</figure>
-					<p>Illustrations should fit within a 200&#160;dp by 200&#160;dp square. Some illustrations may need to be taller than they are wide (and visa versa) but overall illustrations should look balanced within their 200&#160;dp boundary.</p>
-					<p>Illustrations must adhere to the colors outlined in this Style Guide, however no illustrations should use Base0. Illustrations may include transparent elements or cut outs, however no elements may be depicted as semi-transparent or with a reduced opacity. All elements should either be transparent or displayed at 100% opacity.</p>
-					<p>When designing a new illustration, focus on legibility. Illustrations consist of a single element or focused composition. Illustrations should be simple, clear, universal and memorable.</p>
-					<p>Illustrations should be simple. They use monochromatic vector-based shapes with the following properties:</p>
-					<ul>
-						<li>Filled areas. Shapes are defined by filled areas as opposed to outlines.</li>
-						<li>Rounded corners. Corners are slightly rounded (2&#160;dp) to make shapes more friendly and welcoming, but not too much to look goofy.</li>
-						<li>2&#160;dp outline stroke, except for illustrations that appear on colored backgrounds.</li>
-					</ul>
-					<p>Illustrations must adhere to the colors outlined in this Style Guide, however no illustrations should use Base0. As a general recommendation, an illustration should utilize no more than 3 accent or supplementary colors (eg. Blue50, Red50, Green50 and Yellow50) to avoid visual complexity. Additionally, special care should be taken when using reds with greens or blues in the same composition. Users with red-green color blindness may have difficulty differentiating between red and green elements, especially if they are overlapping. Red and blue elements should also be treated with care so as to avoid the visual illusion of <a href="https://en.wikipedia.org/wiki/Chromostereopsis" target="_blank" rel="noopener">chromostereopsis</a>. Illustrations may include transparent elements or cut outs, however all elements should be shown as either 0 or 100% opacity.</p>
+					<section id="creating-illustrations">
+						<h2>Creating illustrations</h2>
+						<figure class="illustrations-case-study">
+							<img src="img/visual-style/illustrations-colored-background.svg" onerror="this.src='img/visual-style/illustrations-colored-background.png'" alt="Illustration on colored background">
+							<img src="img/visual-style/illustrations-white-background.svg" onerror="this.src='img/visual-style/illustrations-white-background.png'" alt="Illustration on white background">
+							<img src="img/visual-style/illustrations-grey-background.svg" onerror="this.src='img/visual-style/illustrations-grey-background.png'" alt="Illustration on grey background">
+							<figcaption class="figure__caption">In production case studies</figcaption>
+						</figure>
+						<p>Illustrations should fit within a 200&#160;dp by 200&#160;dp square. Some illustrations may need to be taller than they are wide (and visa versa) but overall illustrations should look balanced within their 200&#160;dp boundary.</p>
+						<p>Illustrations must adhere to the colors outlined in this Style Guide, however no illustrations should use Base0. Illustrations may include transparent elements or cut outs, however no elements may be depicted as semi-transparent or with a reduced opacity. All elements should either be transparent or displayed at 100% opacity.</p>
+						<p>When designing a new illustration, focus on legibility. Illustrations consist of a single element or focused composition. Illustrations should be simple, clear, universal and memorable.</p>
+						<p>Illustrations should be simple. They use monochromatic vector-based shapes with the following properties:</p>
+						<ul>
+							<li>Filled areas. Shapes are defined by filled areas as opposed to outlines.</li>
+							<li>Rounded corners. Corners are slightly rounded (2&#160;dp) to make shapes more friendly and welcoming, but not too much to look goofy.</li>
+							<li>2&#160;dp outline stroke, except for illustrations that appear on colored backgrounds.</li>
+						</ul>
+						<p>Illustrations must adhere to the colors outlined in this Style Guide, however no illustrations should use Base0. As a general recommendation, an illustration should utilize no more than 3 accent or supplementary colors (eg. Blue50, Red50, Green50 and Yellow50) to avoid visual complexity. Additionally, special care should be taken when using reds with greens or blues in the same composition. Users with red-green color blindness may have difficulty differentiating between red and green elements, especially if they are overlapping. Red and blue elements should also be treated with care so as to avoid the visual illusion of <a href="https://en.wikipedia.org/wiki/Chromostereopsis" target="_blank" rel="noopener">chromostereopsis</a>. Illustrations may include transparent elements or cut outs, however all elements should be shown as either 0 or 100% opacity.</p>
+					</section>
 				</main>
 			</div>
 		</div>

--- a/visual-style_images.html
+++ b/visual-style_images.html
@@ -81,15 +81,17 @@
 					<h1 class="page__title">Images</h1>
 						<p>Images are found in Wikimedia projects as standalone contributions and as supplementary content to engage and communicate with individuals.</p>
 
-						<h2>Image selection guidelines</h2>
-						<p>We use images to help increase understanding and engagement with individuals. When using images in our projects, the selections follow general guidelines:</p>
-						<ul>
-							<li><strong>Contextually relevant.</strong> Images relate directly to the subject of the article. An article about bicycles should contain images that relate to, support, and enrich content about bicycles.</li>
-							<li><strong>Neutral point of view.</strong> When showing an image of a shark, consider a side profile photograph of a shark instead of an action shot of a shark preying on another animal.</li>
-							<li><strong>Representation in the most accurate medium.</strong> Use a photograph of Rosalind Franklin in her biographic profile, rather than an artistic drawing. In an article about Donald Duck, use a cartoon still of Donald Duck instead of a photograph of a duck. </li>
-							<li><strong>Good resolution quality.</strong> Images should be high quality.</li>
-							<li><strong>Respects copyright.</strong> Images should be correctly attributed. Use Creative Commons, Fair use, or Public Domain images stored on Wikimedia Commons, and other sources that comply correctly with copyright licensing.</li>
-						</ul>
+						<section id="image-selection">
+							<h2>Image selection</h2>
+							<p>We use images to help increase understanding and engagement with individuals. When using images in our projects, the selections follow general guidelines:</p>
+							<ul>
+								<li><strong>Contextually relevant.</strong> Images relate directly to the subject of the article. An article about bicycles should contain images that relate to, support, and enrich content about bicycles.</li>
+								<li><strong>Neutral point of view.</strong> When showing an image of a shark, consider a side profile photograph of a shark instead of an action shot of a shark preying on another animal.</li>
+								<li><strong>Representation in the most accurate medium.</strong> Use a photograph of Rosalind Franklin in her biographic profile, rather than an artistic drawing. In an article about Donald Duck, use a cartoon still of Donald Duck instead of a photograph of a duck. </li>
+								<li><strong>Good resolution quality.</strong> Images should be high quality.</li>
+								<li><strong>Respects copyright.</strong> Images should be correctly attributed. Use Creative Commons, Fair use, or Public Domain images stored on Wikimedia Commons, and other sources that comply correctly with copyright licensing.</li>
+							</ul>
+						</section>
 				</main>
 			</div>
 		</div>

--- a/visual-style_typography.html
+++ b/visual-style_typography.html
@@ -83,82 +83,88 @@
 					<p>Wikimedia projects rely on writing and reading. Typography is a key component of their design. Consider the typeface, size, style, and spacing of your text to achieve good <a href="https://en.wikipedia.org/wiki/Readability">readability</a>. Our typographic choices make our content accessible, present it in a neutral way, and convey its reliability.</p>
 					<img src="img/visual-style/typography-specimen.svg" onerror="this.src='img/visual-style/typography-specimen.png'" alt="Lato and Charter typeface specimen" role="img">
 
-					<h2>Readability</h2>
-					<p>Content should be readable by everyone, regardless of their circumstances. Color blindess or the sun on a device's screen should not be barriers to access.</p>
-					<img src="img/visual-style/typography-readability.png" alt="Content typeset following the guidelines">
+					<section id="readability">
+						<h2>Readability</h2>
+						<p>Content should be readable by everyone, regardless of their circumstances. Color blindess or the sun on a device's screen should not be barriers to access.</p>
+						<img src="img/visual-style/typography-readability.png" alt="Content typeset following the guidelines">
 
-					<h3>Grid</h3>
-					<p>Text layout is key to readability. Typographers and typesetters have been using grids to lay out text for centuries. We lay our content on a horizontal and a vertical grid.</p>
-					<img src="img/visual-style/typography-readability.svg" onerror="this.src='img/visual-style/typography-readability.png'" alt="Content typeset following the guidelines" role="img">
-					<p>The whitespace between sections, complimentary block elements like images, and headings should be consistent and proportional to rest of the whitespace.</p>
+						<h3>Grid</h3>
+						<p>Text layout is key to readability. Typographers and typesetters have been using grids to lay out text for centuries. We lay our content on a horizontal and a vertical grid.</p>
+						<img src="img/visual-style/typography-readability.svg" onerror="this.src='img/visual-style/typography-readability.png'" alt="Content typeset following the guidelines" role="img">
+						<p>The whitespace between sections, complimentary block elements like images, and headings should be consistent and proportional to rest of the whitespace.</p>
 
-					<h3>Contrast</h3>
-					<p>When using text, make sure that it provides enough contrast to be read comfortably. Check the contrast between the colors used for the text and its background. Provide at least level AA sufficient contrast (4.5:1). The <a href="visual-style_colors.html">color palette</a> provides the contrast levels for pure white and black surfaces, but you need to ensure the contrast on other combinations.</p>
-					<div class="figures-do-dont figures-do-dont--contrast">
-						<figure class="figure figure--do">
-							<div class="figure__contents">Bento (弁当 bentō) is a single-portion take-out or home-packed meal common in Japanese cuisine.</div>
-							<figcaption class="figure__caption"><span class="do">Do: </span>Contrast against the background</figcaption>
+						<h3>Contrast</h3>
+						<p>When using text, make sure that it provides enough contrast to be read comfortably. Check the contrast between the colors used for the text and its background. Provide at least level AA sufficient contrast (4.5:1). The <a href="visual-style_colors.html">color palette</a> provides the contrast levels for pure white and black surfaces, but you need to ensure the contrast on other combinations.</p>
+						<div class="figures-do-dont figures-do-dont--contrast">
+							<figure class="figure figure--do">
+								<div class="figure__contents">Bento (弁当 bentō) is a single-portion take-out or home-packed meal common in Japanese cuisine.</div>
+								<figcaption class="figure__caption"><span class="do">Do: </span>Contrast against the background</figcaption>
+							</figure>
+							<figure class="figure figure--dont" aria-disabled="true">
+								<div class="figure__contents">Bento (弁当 bentō) is a single-portion take-out or home-packed meal common in Japanese cuisine.</div>
+								<figcaption class="figure__caption"><span class="dont">Don't: </span>Low contrast below 4.5:1, especially at smaller sizes, makes text harder to read.</figcaption>
+							</figure>
+						</div>
+
+						<h3>Tracking and leading</h3>
+						<p><strong>Text spacing.</strong> How text is placed in space can affect its readability. Follow these considerations for text paragraphs:</p>
+						<ul>
+							<li>Line length for reading in English is ideally no longer than <a href="https://en.wikipedia.org/wiki/The_Elements_of_Typographic_Style">75 characters</a>.</li>
+							<li>Line height should be 1.6 times the size of the font used.</li>
+						</ul>
+						<h3>Dynamic text</h3>
+						<p>Content will be available in multiple languages, and text length will vary for pieces of content across languages. Avoid designing interfaces that depend on certain expectations about text length.</p>
+						<figure class="figure figure--full">
+							<img src="img/visual-style/typography-dynamic-text.png" alt="Text shown at different font sizes depending on their length">
+							<figcaption class="figure__caption">Text shown at different font sizes depending on their length.</figcaption>
 						</figure>
-						<figure class="figure figure--dont" aria-disabled="true">
-							<div class="figure__contents">Bento (弁当 bentō) is a single-portion take-out or home-packed meal common in Japanese cuisine.</div>
-							<figcaption class="figure__caption"><span class="dont">Don't: </span>Low contrast below 4.5:1, especially at smaller sizes, makes text harder to read.</figcaption>
-						</figure>
-					</div>
+						<p>Here are few ways to tackle dynamic text:</p>
+						<ul>
+							<li><b>Uncrowded user interface.</b> Design with an eye for <a href="http://lawsofsimplicity.com/los/law-1-reduce.html">simplicity</a>. Consider reducing the number of elements to ensure the remaining ones have enough room. </li>
+							<li><b>Dynamic layout.</b> Make containers expandable, so that they can fit the content.</li>
+							<li><b>Dynamic text.</b> Adjust the size depending on the content. Use a smaller font-size for long content.</li>
+							<li><b>Clipping.</b> Clip the text with ellipsis, only if there is no risk of missing important information or the complete information is reachable through a clear alternative means.</li>
+						</ul>
+					</section>
 
-					<h3>Tracking and leading</h3>
-					<p><strong>Text spacing.</strong> How text is placed in space can affect its readability. Follow these considerations for text paragraphs:</p>
-					<ul>
-						<li>Line length for reading in English is ideally no longer than <a href="https://en.wikipedia.org/wiki/The_Elements_of_Typographic_Style">75 characters</a>.</li>
-						<li>Line height should be 1.6 times the size of the font used.</li>
-					</ul>
-					<h3>Dynamic text</h3>
-					<p>Content will be available in multiple languages, and text length will vary for pieces of content across languages. Avoid designing interfaces that depend on certain expectations about text length.</p>
-					<figure class="figure figure--full">
-						<img src="img/visual-style/typography-dynamic-text.png" alt="Text shown at different font sizes depending on their length">
-						<figcaption class="figure__caption">Text shown at different font sizes depending on their length.</figcaption>
-					</figure>
-					<p>Here are few ways to tackle dynamic text:</p>
-					<ul>
-						<li><b>Uncrowded user interface.</b> Design with an eye for <a href="http://lawsofsimplicity.com/los/law-1-reduce.html">simplicity</a>. Consider reducing the number of elements to ensure the remaining ones have enough room. </li>
-						<li><b>Dynamic layout.</b> Make containers expandable, so that they can fit the content.</li>
-						<li><b>Dynamic text.</b> Adjust the size depending on the content. Use a smaller font-size for long content.</li>
-						<li><b>Clipping.</b> Clip the text with ellipsis, only if there is no risk of missing important information or the complete information is reachable through a clear alternative means.</li>
-					</ul>
+					<section id="typefaces">
+						<h2>Typefaces</h2>
+						<p>Charter (supported by the Charis SIL font implementation) and Lato are the recommended typefaces, when available.</p>
+						<ul>
+							<li>Charter is a serif typeface designed by Matthew Carter in 1987. Charter has a simplified and clean structure that works well, even on low resolution displays. Although <a href="https://en.wikipedia.org/wiki/Bitstream_Charter">Bitstream Charter</a> is the original implementation for Charter, we recommend using <a href="https://en.wikipedia.org/wiki/Charis_SIL">Charis SIL</a> since it provides a wider Unicode support.</li>
+							<li><a href="http://www.latofonts.com/lato-free-fonts/">Lato</a> is a sans-serif typeface designed by Łukasz Dziedzic in 2010. Lato provides good readability even at small sizes.</li>
+						</ul>
+						<p>These fonts are provided as a reference, but you may use similar criteria when those fonts are not available in your context.</p>
 
-					<h2>Typefaces</h2>
-					<p>Charter (supported by the Charis SIL font implementation) and Lato are the recommended typefaces, when available.</p>
-					<ul>
-						<li>Charter is a serif typeface designed by Matthew Carter in 1987. Charter has a simplified and clean structure that works well, even on low resolution displays. Although <a href="https://en.wikipedia.org/wiki/Bitstream_Charter">Bitstream Charter</a> is the original implementation for Charter, we recommend using <a href="https://en.wikipedia.org/wiki/Charis_SIL">Charis SIL</a> since it provides a wider Unicode support.</li>
-						<li><a href="http://www.latofonts.com/lato-free-fonts/">Lato</a> is a sans-serif typeface designed by Łukasz Dziedzic in 2010. Lato provides good readability even at small sizes.</li>
-					</ul>
-					<p>These fonts are provided as a reference, but you may use similar criteria when those fonts are not available in your context.</p>
+						<h3>Font selection criteria</h3>
+						<p>Font selection depends on availability. Fonts are not always available for all scripts or all devices. The criteria for font selection is the following:</p>
+						<ol>
+							<li><b>Readability.</b> Fonts with a bigger x-height and open shapes are preferred.</li>
+							<li><b>Neutral aspect.</b> The font should work with many different kinds of content without adding a particular voice to it.</li>
+							<li><b>Simple shapes.</b> Fonts with less complex shapes work better at smaller sizes, on low-resolution devices, and reduce printing costs.</li>
+							<li><b>Open.</b> Open source fonts are preferred to align with the open knowledge they deliver.</li>
+						</ol>
+						<p>To extend the font family to new scripts or devices, the above criteria should be followed. Common cases in which you need to look for alternatives are:</p>
+						<p><b>Lack of a font delivery mechanism.</b> In cases where custom fonts cannot be delivered to the user (e.g., through web fonts technology), you need to define alternatives. Default fonts such as Lato and Charter/Charis can still be recommended as primary options for users that installed those fonts themselves. A wider set of fallback options from those available in the user device may be needed. Possible fallback options:</p>
+						<ul>
+							<li><a href="https://en.wikipedia.org/wiki/Georgia_(typeface)">Georgia</a> (present in many devices) can be a fallback for Charter.</li>
+							<li>Device default sans-serif font would be used in the absence of Lato.</li>
+						</ul>
+						<p><b>Language support.</b> There is no font that supports all languages. Individual language communities can identify fonts that better support their languages, taking into account the above criteria. Possible fallback option incude:</p>
+						<ul>
+							<li>The <a href="https://en.wikipedia.org/wiki/Noto_fonts">Noto family</a> provides a great coverage of languages, providing good alternatives for both serif and sans-serif typefaces.</li>
+						</ul>
+					</section>
 
-					<h3>Font selection criteria</h3>
-					<p>Font selection depends on availability. Fonts are not always available for all scripts or all devices. The criteria for font selection is the following:</p>
-					<ol>
-						<li><b>Readability.</b> Fonts with a bigger x-height and open shapes are preferred.</li>
-						<li><b>Neutral aspect.</b> The font should work with many different kinds of content without adding a particular voice to it.</li>
-						<li><b>Simple shapes.</b> Fonts with less complex shapes work better at smaller sizes, on low-resolution devices, and reduce printing costs.</li>
-						<li><b>Open.</b> Open source fonts are preferred to align with the open knowledge they deliver.</li>
-					</ol>
-					<p>To extend the font family to new scripts or devices, the above criteria should be followed. Common cases in which you need to look for alternatives are:</p>
-					<p><b>Lack of a font delivery mechanism.</b> In cases where custom fonts cannot be delivered to the user (e.g., through web fonts technology), you need to define alternatives. Default fonts such as Lato and Charter/Charis can still be recommended as primary options for users that installed those fonts themselves. A wider set of fallback options from those available in the user device may be needed. Possible fallback options:</p>
-					<ul>
-						<li><a href="https://en.wikipedia.org/wiki/Georgia_(typeface)">Georgia</a> (present in many devices) can be a fallback for Charter.</li>
-						<li>Device default sans-serif font would be used in the absence of Lato.</li>
-					</ul>
-					<p><b>Language support.</b> There is no font that supports all languages. Individual language communities can identify fonts that better support their languages, taking into account the above criteria. Possible fallback option incude:</p>
-					<ul>
-						<li>The <a href="https://en.wikipedia.org/wiki/Noto_fonts">Noto family</a> provides a great coverage of languages, providing good alternatives for both serif and sans-serif typefaces.</li>
-					</ul>
-
-					<h2>Use of styles</h2>
-					<p>The recommended styles are intended to optimize readability of Wikipedia’s dense encyclopedic content.</p>
-					<p>Using the body text size of 16 scale-independent pixels (sp) as a base, a typographic scale of 1.125 was used to derive a harmonious rhythm between font-sizes for various headings and body copy.</p>
-					<img src="img/visual-style/typography-scale.png" alt="Scale of sizes used for text">
-					<p>The scale-independent pixels can result in a different number of actual pixels in the user screen due to screen density or user preferences. A 16&#160;sp text is rendered as 16&#160;px in a 1x device at standard zoom level, but it becomes 21&#160;px in a 2x device (or when zoomed 200% on a 1x device).</p>
-					<p>Common text styles are based on the defined scale to clearly communicate the content hierarchy. </p>
-					<img src="img/visual-style/typography-styles.png" alt="Text styles visually listed">
+					<section id="use-of-styles">
+						<h2>Use of styles</h2>
+						<p>The recommended styles are intended to optimize readability of Wikipedia’s dense encyclopedic content.</p>
+						<p>Using the body text size of 16 scale-independent pixels (sp) as a base, a typographic scale of 1.125 was used to derive a harmonious rhythm between font-sizes for various headings and body copy.</p>
+						<img src="img/visual-style/typography-scale.png" alt="Scale of sizes used for text">
+						<p>The scale-independent pixels can result in a different number of actual pixels in the user screen due to screen density or user preferences. A 16&#160;sp text is rendered as 16&#160;px in a 1x device at standard zoom level, but it becomes 21&#160;px in a 2x device (or when zoomed 200% on a 1x device).</p>
+						<p>Common text styles are based on the defined scale to clearly communicate the content hierarchy. </p>
+						<img src="img/visual-style/typography-styles.png" alt="Text styles visually listed">
+					</section>
 				</main>
 			</div>
 		</div>


### PR DESCRIPTION
Adding `section` elements and `id`s as jump anchors.
When referring to sections like “Accent colors” in code or documentation
it's preferrable to have direct link options. We've already established
similar ones on start page and design principles.
Also slightly changing two headings to reflect other headings structure.