### PR TITLE
build: Add JavaScript concatenation and uglify

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,9 @@ module.exports = function ( grunt ) {
 		// With minifier
 		postCssProcessorsMin = postCssProcessorsDev.concat( [ require( 'cssnano' )() ] );
 
+	grunt.loadNpmTasks( 'grunt-contrib-concat' );
 	grunt.loadNpmTasks( 'grunt-contrib-watch' );
+	grunt.loadNpmTasks( 'grunt-contrib-uglify' );
 	grunt.loadNpmTasks( 'grunt-eslint' );
 	grunt.loadNpmTasks( 'grunt-postcss' );
 	grunt.loadNpmTasks( 'grunt-sketch' );
@@ -39,15 +41,49 @@ module.exports = function ( grunt ) {
 	grunt.loadNpmTasks( 'grunt-svgmin' );
 
 	grunt.initConfig( {
-		// Lint – Code
+		// Build – JavaScript
+		concat: {
+			options: {
+				sourceMap: true,
+				sourceMapName: function ( concatFileName ) {
+					return concatFileName + '.map.json';
+				}
+			},
+			files: {
+				src: [
+					'js/src/fonts-loader.js'
+				],
+				dest: 'js/wikimedia-design-style-guide.concat.js'
+			}
+		},
+
+		uglify: {
+			options: {
+				sourceMap: true,
+				sourceMapIncludeSources: true,
+				sourceMapName: function ( uglifyFileName ) {
+					return uglifyFileName + '.map.json';
+				},
+				report: 'gzip'
+			},
+			js: {
+				expand: true,
+				src: 'js/*.concat.js',
+				ext: '.min.js',
+				extDot: 'first'
+			}
+		},
+
+		// Lint – JavaScript
 		eslint: {
 			dev: [
-				'*.js',
+				'Gruntfile.js',
+				'js/src/**/*.js',
 				'!js/vendor/**/*.js'
 			]
 		},
 
-		// Lint – Styles
+		// Lint – Stylesheets
 		stylelint: {
 			src: [
 				'css/*.dev.css',
@@ -55,7 +91,7 @@ module.exports = function ( grunt ) {
 			]
 		},
 
-		// Postprocessing Styles
+		// Postprocessing Stylesheets
 		postcss: {
 			// Output unminified compiled CSS file into `build` dir
 			dev: {
@@ -65,12 +101,12 @@ module.exports = function ( grunt ) {
 				src: 'css/wmui-style-guide.dev.css',
 				dest: 'css/build/wmui-style-guide.css'
 			},
-			// Output minified compiled CSS file +  src maps into `build` dir
+			// Output minified compiled CSS file + source maps into `build` dir
 			min: {
 				options: {
 					map: {
-						inline: false, // save all sourcemaps as separate files...
-						annotation: 'css/build/' // ...to the specified directory
+						inline: false, // Save all source maps as separate files…
+						annotation: 'css/build/' // …to the specified directory
 					},
 					processors: postCssProcessorsMin
 				},

--- a/design-principles.html
+++ b/design-principles.html
@@ -17,7 +17,7 @@
 	<script src="js/vendor/ie/html5shiv-3.7.3.min.js"></script>
 	<![endif]-->
 	<link rel="preload" href="fonts/Charter_regular.woff2" as="font" type="font/woff2" crossorigin>
-	<script src="js/fonts-loader.js" async></script>
+	<script src="js/wikimedia-design-style-guide.min.js" async></script>
 	<script>
 		var _paq = _paq || [];
 		_paq.push(['setDomains', ['*.design.wikimedia.org.']]);

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 	<script src="js/vendor/ie/html5shiv-3.7.3.min.js"></script>
 	<![endif]-->
 	<link rel="preload" href="fonts/Charter_regular.woff2" as="font" type="font/woff2" crossorigin>
-	<script src="js/fonts-loader.js" async></script>
+	<script src="js/wikimedia-design-style-guide.min.js" async></script>
 	<script>
 		var _paq = _paq || [];
 		_paq.push(['setDomains', ['*.design.wikimedia.org.']]);

--- a/js/src/fonts-loader.js
+++ b/js/src/fonts-loader.js
@@ -1,5 +1,5 @@
+/* eslint-disable vars-on-top, one-var */
 if ( document.head && 'Promise' in window ) {
-
 	var html = document.documentElement;
 
 	if ( sessionStorage.getItem( 'fontsLoaded' ) ) {
@@ -9,13 +9,13 @@ if ( document.head && 'Promise' in window ) {
 		script.src = './js/vendor/fontfaceobserver/fontfaceobserver.standalone.js';
 
 		script.onload = function () {
-			var serif = new FontFaceObserver( 'Charter' );
+			var serif = new FontFaceObserver( 'Charter' ); /* eslint-disable-line no-undef */
 
-			Promise.all( [
+			Promise.all( [ /* eslint-disable-line no-undef */
 				serif.load()
 			] ).then( function () {
 				html.classList.add( 'fonts-loaded' );
-				sessionStorage.setItem( 'fontsLoaded' , 1);
+				sessionStorage.setItem( 'fontsLoaded', 1 );
 			} );
 		};
 		document.head.appendChild( script );

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "cssnano": "4.1.0",
     "eslint-config-wikimedia": "0.8.1",
     "grunt": "1.0.3",
+    "grunt-contrib-concat": "^1.0.1",
+    "grunt-contrib-uglify": "^4.0.0",
     "grunt-contrib-watch": "1.1.0",
     "grunt-eslint": "21.0.0",
     "grunt-exec": "3.0.0",

--- a/visual-style.html
+++ b/visual-style.html
@@ -18,7 +18,7 @@
 	<script src="js/vendor/ie/respond-1.4.2.min.js"></script>
 	<![endif]-->
 	<link rel="preload" href="fonts/Charter_regular.woff2" as="font" type="font/woff2" crossorigin>
-	<script src="js/fonts-loader.js" async></script>
+	<script src="js/wikimedia-design-style-guide.min.js" async></script>
 	<script>
 		var _paq = _paq || [];
 		_paq.push(['setDomains', ['*.design.wikimedia.org.']]);

--- a/visual-style_colors.html
+++ b/visual-style_colors.html
@@ -17,7 +17,7 @@
 	<script src="js/vendor/ie/html5shiv-3.7.3.min.js"></script>
 	<![endif]-->
 	<link rel="preload" href="fonts/Charter_regular.woff2" as="font" type="font/woff2" crossorigin>
-	<script src="js/fonts-loader.js" async></script>
+	<script src="js/wikimedia-design-style-guide.min.js" async></script>
 	<script>
 		var _paq = _paq || [];
 		_paq.push(['setDomains', ['*.design.wikimedia.org.']]);

--- a/visual-style_icons.html
+++ b/visual-style_icons.html
@@ -17,7 +17,7 @@
 	<script src="js/vendor/ie/html5shiv-3.7.3.min.js"></script>
 	<![endif]-->
 	<link rel="preload" href="fonts/Charter_regular.woff2" as="font" type="font/woff2" crossorigin>
-	<script src="js/fonts-loader.js" async></script>
+	<script src="js/wikimedia-design-style-guide.min.js" async></script>
 	<script>
 		var _paq = _paq || [];
 		_paq.push(['setDomains', ['*.design.wikimedia.org.']]);

--- a/visual-style_illustrations.html
+++ b/visual-style_illustrations.html
@@ -17,7 +17,7 @@
 	<script src="js/vendor/ie/html5shiv-3.7.3.min.js"></script>
 	<![endif]-->
 	<link rel="preload" href="fonts/Charter_regular.woff2" as="font" type="font/woff2" crossorigin>
-	<script src="js/fonts-loader.js" async></script>
+	<script src="js/wikimedia-design-style-guide.min.js" async></script>
 	<script>
 		var _paq = _paq || [];
 		_paq.push(['setDomains', ['*.design.wikimedia.org.']]);

--- a/visual-style_images.html
+++ b/visual-style_images.html
@@ -17,7 +17,7 @@
 	<script src="js/vendor/ie/html5shiv-3.7.3.min.js"></script>
 	<![endif]-->
 	<link rel="preload" href="fonts/Charter_regular.woff2" as="font" type="font/woff2" crossorigin>
-	<script src="js/fonts-loader.js" async></script>
+	<script src="js/wikimedia-design-style-guide.min.js" async></script>
 	<script>
 		var _paq = _paq || [];
 		_paq.push(['setDomains', ['*.design.wikimedia.org.']]);

--- a/visual-style_typography.html
+++ b/visual-style_typography.html
@@ -17,7 +17,7 @@
 	<script src="js/vendor/ie/html5shiv-3.7.3.min.js"></script>
 	<![endif]-->
 	<link rel="preload" href="fonts/Charter_regular.woff2" as="font" type="font/woff2" crossorigin>
-	<script src="js/fonts-loader.js" async></script>
+	<script src="js/wikimedia-design-style-guide.min.js" async></script>
 	<script>
 		var _paq = _paq || [];
 		_paq.push(['setDomains', ['*.design.wikimedia.org.']]);


### PR DESCRIPTION
- Adding 'grunt-contrib-concat' & 'grunt-contrib-uglify' packages
- Adding corresponding Grunt directives, concat is premise to next
  step of incorporating Matomo's `embedTrackingCode` too
- Changing file structure, so source files for further manipulation
  live in 'src' while in-production files go into 'js'
- Also amending some JS code to coding standards and Gruntfile code
  comments

Bug: [T204971](https://phabricator.wikimedia.org/T204971)