### PR TITLE
“Resources”: Fix 404 and slightly amend layout

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -82,18 +82,15 @@
 							</div>
 							<span class="resources-table__cell"></span>
 							<span class="resources-table__cell"></span>
-							<span class="resources-table__cell"></span>
 						</header>
 						<ul class="resources-table__body">
 							<li class="resources-table__cell">Collection of all “WikimediaUI” icons<br>The ZIP file contains all single SVGs, find them also in folder 'resources/WikimediaUI-icons-SVGs'.</li>
-							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI_icons.ai" target="_blank" rel="noopener" title="Collection of all icons in Adobe Illustrator file">Download AI</a></li>
+							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI-icons.ai" target="_blank" rel="noopener" title="Collection of all icons in Adobe Illustrator file">Download AI</a></li>
 							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI-icons-SVGs.zip" target="_blank" rel="noopener" title="Collection of all icons as SVGs in ZIP file">Download ZIP</a></li>
-							<li class="resources-table__cell" aria-hidden="true"></li>
 						</ul>
 						<ul class="resources-table__body">
 							<li class="resources-table__cell">Template for <a href="visual-style_icons.html#creating-icons">creating new conforming icons</a><br>Specific template forms – circular, diagonal, long, square and tall – you can find in folder 'resources/WikimediaUI-icon_template_SVG_shapes'.</li>
-							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI-icon_template.ai" target="_blank" rel="noopener" title="Adobe Illustrator template file">Download AI</a></li>
-							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI-icon_template.sketch" target="_blank" rel="noopener">Download Sketch</a></li>
+							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI-icon_template.ai" target="_blank" rel="noopener" title="Adobe Illustrator template file">Download AI</a><br><a class="lnk-resource" href="resources/WikimediaUI-icon_template.sketch" target="_blank" rel="noopener">Download Sketch</a></li>
 							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI-icon_template.svg" target="_blank" rel="noopener">Download SVG</a></li>
 						</ul>
 					</section>


### PR DESCRIPTION
Fixing 404 on Adobe Illustrator file for icons and amend layout to
two download columns.