### PR TITLE
“Visual Style – Typography”: Remove 'Helvetica Neue' from system font…

### DIFF
--- a/visual-style_typography.html
+++ b/visual-style_typography.html
@@ -130,17 +130,17 @@
 						<ul>
 							<li><b><a href="https://en.wikipedia.org/wiki/Georgia_(typeface)">Georgia</a></b> (present in many operating systems) can be a fallback for Charter.</li>
 							<li><b>Operating system default sans-serif typefaces aka system fonts</b> would be used when performance of web font loading, cross-language issues come into play or in the absence of Lato. <br>Equivalent CSS code is <pre><span style="color:#72777d;">/**
- * System font stack
+ * System font stack for sans-serif fonts
  *
- * `-apple-system` – Support: Safari for OS X and iOS ('San Francisco')
- * `BlinkMacSystemFont` – Chrome < 56 for OS X ('San Francisco')
+ * `-apple-system` ('San Francisco' font) – Support Safari 9+ macOS and iOS, Firefox macOS
+ * `BlinkMacSystemFont` ('San Francisco' font) – Chrome 48+ macOS and iOS
  * `Segoe UI` – Windows Vista & newer
- * `Roboto` – Android
- * `Lato` – Wikimedia Design choice
- * `Helvetica Neue, Helvetica, Arial, sans-serif` – (Generic) Web fallback
+ * `Roboto` – Android 4.0+
+ * `Lato` – Wikimedia Design choice, OFL licensed
+ * `Helvetica, Arial, sans-serif` – (Generic) Web fallback
  * Note that standard `system-ui` value has resulted in unresolved side-effects in certain OS/language combinations as of now and is therefore not included.
  */</span>
-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif;</pre></li>
+font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Lato, Helvetica, Arial, sans-serif;</pre></li>
 						</ul>
 						<p><b>Language support.</b> There is no font that supports all languages. Individual language communities can identify fonts that better support their languages, taking into account the above criteria. Possible fallback option incude:</p>
 						<ul>


### PR DESCRIPTION
… stack

Removing 'Helvetica Neue' due to it having resulted in side-effects
in certain operating systems.

Bug [T175877](https://phabricator.wikimedia.org/T175877)