### PR TITLE
“Visual Style – Typography”: Amend monospace font stack

### DIFF
--- a/visual-style_typography.html
+++ b/visual-style_typography.html
@@ -234,7 +234,16 @@ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Lato, Helvet
 							</dd>
 							<dt class="typography-styles__code">Code</dt>
 							<dd>
-								<pre><span style="color:#72777d;">'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', 'Courier New', monospace 14px</span><br>&lt;a href="https://www.wikipedia.org/"&gt;A link to Wikipedia!&lt;/a&gt;</pre>
+								<pre><span style="color:#72777d;">/**
+ * System font stack for monospace fonts
+ *
+ * `Menlo` – macOS 10.6+
+ * `Consolas` – Windows Vista & newer
+ * `Liberation Mono` – Fedora, Ubuntu, … OFL licensed
+ * `'Courier New', monospace` – (Generic) web font fallback
+ */</span>
+font-family: 'Menlo', 'Consolas', 'Liberation Mono', 'Courier New', monospace;
+font-size: 14px;</pre>
 							</dd>
 						</dl>
 					</section>


### PR DESCRIPTION
Removing 'SFMono-Regular' as it needs to be specifically installed.
It just adds bytes for huge majority of users.