### PR TITLE
“Visual Style – Icons”: Link template and resources clearer

### DIFF
--- a/visual-style_icons.html
+++ b/visual-style_icons.html
@@ -98,7 +98,7 @@
 					<section id="creating-icons">
 						<h2>Creating icons</h2>
 						<figure class="figure figure--full">
-							<figcaption>Icons follow a template. The default canvas is 20 x 20&#160;dp. In order to allow for optical adjustments, a different margin is applied depending on the shape of the icon.</figcaption>
+							<figcaption><a href="https://design.wikimedia.org/style-guide/resources/WikimediaUI-icon_template.sketch" target="_blank" rel="noopener">Icons follow a template</a>. The default canvas is 20 x 20&#160;dp. In order to allow for optical adjustments, a different margin is applied depending on the shape of the icon.</figcaption>
 							<img src="img/visual-style/icons-optical-adjustment.svg" onerror="this.src='img/visual-style/icons-optical-adjustment.png'" alt="Icon sizes at different shapes for optical adjustment" role="img">
 						</figure>
 						<p>Different shapes have different perceived sizes. A 1&#160;dp margin for square-shaped icon is used. A circle uses the full 20 x 20&#160;dp canvas available to reach a similar perceived size.</p>
@@ -124,7 +124,8 @@
 
 					<section id="resources">
 						<h2>Resources</h2>
-						<p>The <a href="https://doc.wikimedia.org/oojs-ui/master/demos/?page=icons&theme=wikimediaui&direction=ltr&platform=desktop#icons-mediawiki-ltr">OOUI icon repository</a> provides a list of the currently available icons.</p>
+						<p>The <a href="https://doc.wikimedia.org/oojs-ui/master/demos/?page=icons&theme=wikimediaui&direction=ltr&platform=desktop#icons-mediawiki-ltr">OOUI icon repository</a> provides a overview listing of the currently available icons.</p>
+						<p>You also find all icons up-to-date in current repo's 'resources' directory as <a href="resources/WikimediaUI-icons.ai" target="_blank" rel="noopener" title="Collection of all icons in Adobe Illustrator file">Adobe Illustrator source file</a> and as single, <a href="https://www.mediawiki.org/wiki/Manual:Coding_conventions/SVG" target="_blank" rel="noopener">SVGO production optimized</a> SVGs.</p>
 					</section>
 
 					<section id="references">


### PR DESCRIPTION
Linking to template file and to icon source and SVG files to clarify
icon guidelines and resources availability.

Bug: [T229629](https://phabricator.wikimedia.org/T229629)