### PR TITLE
“Visual style – Typography”: Remove uninsightful link and fix typo

### DIFF
--- a/visual-style_typography.html
+++ b/visual-style_typography.html
@@ -66,7 +66,7 @@
 
 					<section id="readability">
 						<h2>Readability</h2>
-						<p>Content should be readable by everyone, regardless of their circumstances. Color blindess or the sun on a device's screen should not be barriers to access.</p>
+						<p>Content should be readable by everyone, regardless of their circumstances. Color blindness or the sun on a device's screen should not be barriers to access.</p>
 
 						<h3>Contrast</h3>
 						<p>When using text, make sure that it provides enough contrast to be read comfortably. Check the contrast between the colors used for the text and its background. Provide at least level AA sufficient contrast (4.5:1). The <a href="visual-style_colors.html">color palette</a> provides the contrast levels for pure white and black surfaces, but you need to ensure the contrast on other combinations.</p>
@@ -95,7 +95,7 @@
 						</figure>
 						<p>Here are few ways to tackle dynamic text:</p>
 						<ul>
-							<li><b>Uncrowded user interface.</b> Design with an eye for <a href="http://lawsofsimplicity.com/los/law-1-reduce.html">simplicity</a>. Consider reducing the number of elements to ensure the remaining ones have enough room. </li>
+							<li><b>Uncrowded user interface.</b> Design with an eye for simplicity. Consider reducing the number of elements to ensure the remaining ones have enough room. </li>
 							<li><b>Dynamic layout.</b> Make containers expandable, so that they can fit the content.</li>
 							<li><b>Dynamic text.</b> Adjust the size depending on the content. Use a smaller font-size for long content.</li>
 							<li><b>Clipping.</b> Clip the text with ellipsis, only if there is no risk of missing important information or the complete information is reachable through a clear alternative means.</li>


### PR DESCRIPTION
Remove “laws of simplicity” link as it doesn't provide value here and
explanation is already enough. Also fixing small typo.