### PR TITLE
build: Add 'grunt-replace' & ensure `sans-serif` fallback in components SVGs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,6 +28,7 @@ module.exports = function ( grunt ) {
 	grunt.loadNpmTasks( 'grunt-contrib-uglify' );
 	grunt.loadNpmTasks( 'grunt-eslint' );
 	grunt.loadNpmTasks( 'grunt-postcss' );
+	grunt.loadNpmTasks( 'grunt-replace' );
 	grunt.loadNpmTasks( 'grunt-sketch' );
 	grunt.loadNpmTasks( 'grunt-stylelint' );
 	grunt.loadNpmTasks( 'grunt-svgmin' );
@@ -305,7 +306,7 @@ module.exports = function ( grunt ) {
 				plugins: [ {
 					cleanupIDs: false
 				}, {
-					removeDesc: false
+					removeDesc: true
 				}, {
 					removeRasterImages: true
 				}, {
@@ -327,6 +328,32 @@ module.exports = function ( grunt ) {
 					],
 					dest: './',
 					ext: '.svg'
+				} ]
+			}
+		},
+
+		replace: {
+			dist: {
+				options: {
+					patterns: [
+						{
+							match: /Helvetica Neue"/g,
+							replacement: 'Helvetica Neue, sans-serif"'
+						},
+						{
+							match: /Lato"/g,
+							replacement: 'Lato, sans-serif"'
+						}
+					]
+				},
+				files: [ {
+					expand: true,
+					cwd: './',
+					src: [
+						'img/components/*.svg',
+						'resources/WikimediaUI-components_overview.svg'
+					],
+					dest: './'
 				} ]
 			}
 		},

--- a/img/components/button_groups_intro.svg
+++ b/img/components/button_groups_intro.svg
@@ -16,16 +16,16 @@
 					<path id="Line-Copy" stroke="#A2A9B1" stroke-linecap="square" d="M358.5.5v33.015"/>
 					<path id="Line-Copy-10" stroke="#767676" stroke-linecap="square" d="M438.5.5v32.015"/>
 					<path id="Line-Copy-13" stroke="#A2A9B1" stroke-linecap="square" d="M438.5.5v32.015"/>
-					<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="220.392" y="24">All</tspan>
 					</text>
-					<text id="Pages-3-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Pages-3-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="290.296" y="24">Pages</tspan>
 					</text>
-					<text id="Other" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Other" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="463.512" y="24">Other</tspan>
 					</text>
-					<text id="Talk-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Talk-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="382.752" y="24">Talk</tspan>
 					</text>
 				</g>

--- a/img/components/button_groups_states.svg
+++ b/img/components/button_groups_states.svg
@@ -69,13 +69,13 @@
 						<g id="Button-/-:disabled" transform="translate(0 .5)">
 							<rect id="BG" width="342" height="33" x="-.5" y="-.5" fill="#C8CCD1" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1" rx="2"/>
 						</g>
-						<text id="Other" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="Other" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="270" y="23.5">Other</tspan>
 						</text>
-						<text id="Pages" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="Pages" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="96" y="23.5">Pages</tspan>
 						</text>
-						<text id="All" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="All" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="27" y="23.5">All</tspan>
 						</text>
 						<path id="Path-115" stroke="#FFF" stroke-linecap="square" d="M246.5.115v33"/>
@@ -86,32 +86,32 @@
 					<path id="Line-Copy" stroke="#A2A9B1" stroke-linecap="square" d="M358.5.5v33.015"/>
 					<path id="Line-Copy-10" stroke="#767676" stroke-linecap="square" d="M438.5.5v32.015"/>
 					<path id="Line-Copy-13" stroke="#A2A9B1" stroke-linecap="square" d="M438.5.5v32.015"/>
-					<text id="Talk" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Talk" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="381" y="305">Talk</tspan>
 					</text>
-					<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="220.392" y="24">All</tspan>
 					</text>
 					<rect id="Combined-Shape" width="342" height="33" x="191.5" y="112.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
 					<rect id="Combined-Shape-Copy" width="342" height="33" x="191.5" y="224.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
 					<path id="Separator" stroke="#CCC" stroke-linecap="square" d="M268 57v32"/>
-					<text id="Pages-3-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Pages-3-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="290.296" y="24">Pages</tspan>
 					</text>
-					<text id="Other" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Other" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="463.512" y="24">Other</tspan>
 					</text>
-					<text id="Talk-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Talk-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="382.752" y="24">Talk</tspan>
 					</text>
 					<rect id="Mediawiki.Neutral.Normal-copy-14" width="342" height="33" x="191.5" y="56.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
-					<text id="All-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="All-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="220.892" y="80">All</tspan>
 					</text>
-					<text id="Pages-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Pages-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="290.296" y="80">Pages</tspan>
 					</text>
-					<text id="Other-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Other-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="463.512" y="80">Other</tspan>
 					</text>
 					<path id="Line-Copy-14" stroke="#A2A9B1" stroke-linecap="square" d="M438.5 57.5v32.015"/>
@@ -119,34 +119,34 @@
 					<path id="Line-Copy-16" stroke="#A2A9B1" stroke-linecap="square" d="M268.5 57.5v32.015"/>
 					<path id="Separator" stroke="#A2A9B1" stroke-linecap="square" d="M268.5 112.5v32.015"/>
 					<path id="Line" stroke="#A2A9B1" stroke-linecap="square" d="M268.5 224.5v32"/>
-					<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="220.392" y="136">All</tspan>
 					</text>
-					<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="220.392" y="248">All</tspan>
 					</text>
-					<text id="Pages-8" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Pages-8" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="290.296" y="136">Pages</tspan>
 					</text>
-					<text id="Pages-8-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Pages-8-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="290.296" y="248">Pages</tspan>
 					</text>
-					<text id="Other-8" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Other-8" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="463.512" y="136">Other</tspan>
 					</text>
-					<text id="Other-8-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Other-8-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="463.512" y="248">Other</tspan>
 					</text>
 					<path id="Mediawiki.Progressive.Hover-7" fill="#FFF" stroke="#A2A9B1" d="M358.5 56.5h80v33h-80z"/>
 					<path id="Mediawiki.Progressive.Hover-8" fill="#EAECF0" stroke="#72777D" d="M358.5 112.5h80v33h-80z"/>
 					<path id="Mediawiki.Progressive.Hover-8-Copy" fill="#1F4999" stroke="#1F4999" d="M358.5 224.5h80v33h-80z"/>
-					<text id="Talk" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Talk" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="383.752" y="80">Talk</tspan>
 					</text>
-					<text id="Talk-6" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Talk-6" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="383.752" y="136">Talk</tspan>
 					</text>
-					<text id="Talk-6-Copy" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Talk-6-Copy" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="382.864" y="248">Talk</tspan>
 					</text>
 					<rect id="Mediawiki.Neutral.Normal-copy-16" width="342" height="33" x="191.5" y="168.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
@@ -154,17 +154,17 @@
 						<path d="M359.5 168.5h80v33h-80z"/>
 						<path stroke-linejoin="square" d="M360.5 169.5h78v31h-78z"/>
 					</g>
-					<text id="All-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="All-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="220.392" y="192">All</tspan>
 					</text>
 					<path id="Line-Copy-21" stroke="#A2A9B1" stroke-linecap="square" d="M268.5 168.5v32.015"/>
-					<text id="Pages-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Pages-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="290.296" y="192">Pages</tspan>
 					</text>
-					<text id="Other-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Other-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="463.512" y="192">Other</tspan>
 					</text>
-					<text id="Talk-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Talk-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="383.752" y="192">Talk</tspan>
 					</text>
 					<g id="_Spec-101-/-16-sp-(1-em)-+-2-*-8-sp-(0.5-em)" stroke-width="4" transform="rotate(-90 246 68)">
@@ -196,7 +196,7 @@
 							<path stroke="#FFF" d="M6.448 11.787l2.721 6.886c.273.675-.094 1.44-.79 1.72-.696.283-1.491-.013-1.765-.692l-2.708-6.853-2.483 2.963-.077.075c-.901.695-1.848.236-1.846-.902L-.474.669c0-.618.027-.82.271-1.028.4-.34.694-.163 1.14.298l10.66 10.157c.793.817.432 1.805-.782 1.933l-4.367-.242z"/>
 						</g>
 					</g>
-					<g id="State-labels" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal" transform="translate(0 9)">
+					<g id="State-labels" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal" transform="translate(0 9)">
 						<text id="Disabled">
 							<tspan x="0" y="295">Disabled</tspan>
 						</text>

--- a/img/components/buttons_normal_&_primary.svg
+++ b/img/components/buttons_normal_&_primary.svg
@@ -68,7 +68,7 @@
 			<g id="PRIMARY-BUTTONS" transform="translate(1759 143)">
 				<g id="Primary-Buttons-X" transform="translate(1 113)">
 					<g id="101-/-Headline--Sub" transform="translate(0 304)">
-						<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+						<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 							<tspan x="0" y="13">ICON + TEXT</tspan>
 						</text>
 						<g id="101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -76,11 +76,11 @@
 						</g>
 					</g>
 					<rect id="Mediawiki.Neutral.Normal-copy-2" width="114" height="33" x="191.5" y="343.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
-					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="0" y="21">Normal</tspan> <tspan x="0" y="77.1">Hover</tspan> <tspan x="0" y="133.2">Active</tspan> <tspan x="0" y="189.3">Focus</tspan> <tspan x="0" y="245.4">Disabled</tspan>
 					</text>
 					<path id="Oval-59" fill="#222" d="M218 370c5.523 0 10-4.477 10-10s-4.477-10-10-10-10 4.477-10 10 4.477 10 10 10z"/>
-					<text id="Button" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Button" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="237" y="367">Button</tspan>
 					</text>
 					<g id="-101-/-16-sp-(1-em)-+-2-*-8-sp-(0.5-em)" stroke-width="4" transform="rotate(90 -21 203)">
@@ -102,7 +102,7 @@
 						<rect width="124" height="33" x="379.5" y="167.5" stroke="#36C" rx="2"/>
 						<rect width="122" height="31" x="380.5" y="168.5" stroke="#36C" stroke-linejoin="square" rx="2"/>
 					</g>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="396.452" y="190">Progressive</tspan>
 					</text>
 					<g id="BG">
@@ -110,39 +110,39 @@
 						<rect width="119" height="31" x="543.5" y="168.5" stroke="#D11D13" stroke-linejoin="square" rx="2"/>
 						<rect width="121" height="33" x="542.5" y="167.5" stroke="#D11D13" rx="2"/>
 					</g>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="559.288" y="191">Destructive</tspan>
 					</text>
 					<rect id="BG" width="124" height="33" x="379.5" y="111.5" fill="#2A4B8D" stroke="#2A4B8D" rx="2"/>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="396.452" y="135">Progressive</tspan>
 					</text>
 					<rect id="BG" width="121" height="33" x="542.5" y="111.5" fill="#951B19" stroke="#951B19" rx="2"/>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="559.288" y="135">Destructive</tspan>
 					</text>
 					<rect id="BG" width="124" height="33" x="379.5" y="55.5" fill="#447FF5" stroke="#447FF5" rx="2"/>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="396.452" y="79">Progressive</tspan>
 					</text>
 					<rect id="BG" width="121" height="33" x="542.5" y="55.5" fill="#B8211F" stroke="#B8211F" rx="2"/>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="559.288" y="79">Destructive</tspan>
 					</text>
 					<rect id="BG" width="124" height="33" x="379.5" y="-.5" fill="#36C" stroke="#36C" rx="2"/>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="396.452" y="23">Progressive</tspan>
 					</text>
 					<rect id="BG" width="120" height="32" x="543" y="0" fill="#D33" rx="2"/>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="559.288" y="23">Destructive</tspan>
 					</text>
 					<rect id="BG" width="124" height="33" x="379.5" y="223.5" fill="#C8CCD1" stroke="#C8CCD1" rx="2"/>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="396" y="247">Progressive</tspan>
 					</text>
 					<rect id="BG" width="121" height="33" x="542.5" y="223.5" fill="#C8CCD1" stroke="#C8CCD1" rx="2"/>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="559" y="247">Destructive</tspan>
 					</text>
 					<rect id="BG" width="89" height="33" x="191.5" y="223.5" fill="#C8CCD1" stroke="#C8CCD1" rx="2"/>
@@ -153,34 +153,34 @@
 					<path id="Line-234" stroke="#D0021B" stroke-width="4" d="M289 360h16"/>
 					<rect id="Mediawiki.Neutral.Normal-copy-3" width="114" height="33" x="380.5" y="343.5" fill="#36C" stroke="#36C" rx="2"/>
 					<circle id="Oval-77" cx="408" cy="360" r="10" fill="#FFF"/>
-					<text id="Button-6" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Button-6" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="426.36" y="367">Button</tspan>
 					</text>
 					<rect id="Mediawiki.Neutral.Normal-copy-6" width="114" height="33" x="542.5" y="343.5" fill="#D11D13" stroke="#D11D13" rx="2"/>
 					<circle id="Oval-82" cx="570" cy="360" r="10" fill="#FFF"/>
-					<text id="Button-8" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Button-8" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="588.36" y="367">Button</tspan>
 					</text>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="208" y="247">Neutral</tspan>
 					</text>
 					<rect id="BG" width="89" height="33" x="191.5" y="-.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
-					<text id="8:16:8:16" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="208" y="23">Neutral</tspan>
 					</text>
 					<rect id="BG" width="89" height="33" x="191.5" y="55.5" fill="#FFF" stroke="#A2A9B1" rx="2"/>
-					<text id="8:16:8:16" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="208" y="79">Neutral</tspan>
 					</text>
 					<rect id="BG" width="89" height="33" x="191.5" y="111.5" fill="#EAECF0" stroke="#9AA0A7" rx="2"/>
-					<text id="8:16:8:16" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="208" y="135">Neutral</tspan>
 					</text>
 					<g id="BG" stroke="#36C">
 						<rect width="89" height="33" x="191.5" y="167.5" rx="2"/>
 						<rect width="87" height="31" x="192.5" y="168.5" stroke-linejoin="square" rx="2"/>
 					</g>
-					<text id="8:16:8:16" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="208" y="191">Neutral</tspan>
 					</text>
 					<g id="Cursor-/-Pointer" transform="translate(259 130)">

--- a/img/components/buttons_normal_intro.svg
+++ b/img/components/buttons_normal_intro.svg
@@ -3,7 +3,7 @@
 		<path fill="#FFF" d="M-1951-255h14720v3264H-1951z"/>
 		<g transform="translate(-191 1)">
 			<rect width="87" height="31" x="192.5" y=".5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
-			<text fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="208" y="22">Neutral</tspan>
 			</text>
 		</g>

--- a/img/components/buttons_primary_destructive_intro.svg
+++ b/img/components/buttons_primary_destructive_intro.svg
@@ -12,7 +12,7 @@
 			<g id="BUTTONS-NORMAL-&amp;-PRIMARY" transform="translate(1759 143)">
 				<g id="Primary-Buttons-X" transform="translate(1 113)">
 					<rect id="BG" width="120" height="32" x="543" y="0" fill="#D33" rx="2"/>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="559.288" y="23">Destructive</tspan>
 					</text>
 				</g>

--- a/img/components/buttons_primary_progressive_intro.svg
+++ b/img/components/buttons_primary_progressive_intro.svg
@@ -12,7 +12,7 @@
 			<g id="BUTTONS-NORMAL-&amp;-PRIMARY" transform="translate(1759 143)">
 				<g id="Primary-Buttons-X" transform="translate(1 113)">
 					<rect id="BG" width="122" height="31" x="380.5" y=".5" fill="#36C" stroke="#36C" rx="2"/>
-					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="396.452" y="23">Progressive</tspan>
 					</text>
 				</g>

--- a/img/components/buttons_toggle_intro.svg
+++ b/img/components/buttons_toggle_intro.svg
@@ -13,13 +13,13 @@
 				<g id="Normal-&amp;-Primary-Buttons-X" transform="translate(1 113)">
 					<g id="Button-toggle-/-!default" transform="translate(192 464)">
 						<rect id="bg" width="107" height="31" x=".5" y=".5" fill="#F8F9FA" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
-						<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="16" y="23">Toggle off</tspan>
 						</text>
 					</g>
 					<g id="Button-toggle-/-:selected" transform="translate(381 464)">
 						<rect id="bg" width="107" height="31" x=".5" y=".5" fill="#2A4B8D" fill-rule="evenodd" stroke="#2A4B8D" stroke-width="1" rx="2"/>
-						<text id="Neutral" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="Neutral" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="16" y="23">Toggle on</tspan>
 						</text>
 					</g>

--- a/img/components/checkboxes_indeterminate_intro_on.svg
+++ b/img/components/checkboxes_indeterminate_intro_on.svg
@@ -4,7 +4,7 @@
 	</defs>
 	<g fill="none" fill-rule="evenodd">
 		<path fill="#FFF" d="M-5514-1013H9206v3264H-5514z"/>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(6 2)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(6 2)">
 			<tspan x="33" y="23">Neutral point – children selected</tspan>
 		</text>
 		<g transform="translate(6 7)">
@@ -20,7 +20,7 @@
 			</g>
 		</g>
 		<g transform="translate(-282 3)">
-			<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="33" y="22">Neutral point</tspan>
 			</text>
 			<rect width="25" height="25" x="-.5" y="-.5" fill="#FFF" stroke="#72777D" rx="2" transform="translate(0 4)"/>

--- a/img/components/checkboxes_intro_off.svg
+++ b/img/components/checkboxes_intro_off.svg
@@ -12,7 +12,7 @@
 			<g id="CHECKBOX-DESKTOP" transform="translate(5038 186)">
 				<g id="Checkbox-X" transform="translate(2 69)">
 					<g id="Checkbox-/-!default" transform="translate(192 1)">
-						<text id="8:16:8:16-copy-15" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-15" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Checkbox-:normal" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" transform="translate(0 4)">

--- a/img/components/checkboxes_intro_on.svg
+++ b/img/components/checkboxes_intro_on.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="158" height="36" viewBox="0 0 158 36">
 	<g fill="none" fill-rule="evenodd">
 		<path fill="#FFF" d="M-5514-254H9206v3264H-5514z"/>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(6 1)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(6 1)">
 			<tspan x="33" y="23">Neutral point</tspan>
 		</text>
 		<g transform="translate(6 6)">
@@ -9,7 +9,7 @@
 			<path fill="#FFF" fill-rule="nonzero" d="M9.444 15.433l-3.321-3.32L5 13.235l4.444 4.452L19 8.131 17.877 7z"/>
 		</g>
 		<g transform="translate(-282 2)">
-			<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="33" y="22">Neutral point</tspan>
 			</text>
 			<rect width="25" height="25" x="-.5" y="-.5" fill="#FFF" stroke="#72777D" rx="2" transform="translate(0 4)"/>

--- a/img/components/checkboxes_states.svg
+++ b/img/components/checkboxes_states.svg
@@ -118,10 +118,10 @@
 			<path fill="#FFF" d="M0 0h14720v3264H0z"/>
 			<g id="CHECKBOX-DESKTOP" transform="translate(5038 186)">
 				<g id="Checkbox-X" transform="translate(2 69)">
-					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="0" y="22.1">Normal</tspan> <tspan x="0" y="78.2">Hover</tspan> <tspan x="0" y="134.3">Active</tspan> <tspan x="0" y="190.4">Focus</tspan> <tspan x="0" y="246.5">Disabled</tspan>
 					</text>
-					<text id="Switched-on" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Switched-on" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="477" y="304">Switched on</tspan>
 					</text>
 					<g id="-101-/-16-sp-(1-em)-+-2-*-4-sp-(0.25-em)" stroke-width="4" transform="rotate(-90 216 38)">
@@ -136,7 +136,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:checked-/-:disabled" transform="translate(480 226)">
-						<text id="8:16:8:16-copy-21" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-21" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Mediawiki.Neutral.Hover-copy-10-+-Imported-Layers-Copy-2" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -147,7 +147,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:checked-/-:hover" transform="translate(480 57)">
-						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<g id="Mediawiki.Neutral.Hover-copy-12-+-Imported-Layers-Copy-3" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -158,7 +158,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:checked-/-:active" transform="translate(480 113)">
-						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Mediawiki.Neutral.Hover-copy-14-+-Imported-Layers-Copy-4" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -169,7 +169,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:checked-/-:focus" transform="translate(480 169)">
-						<text id="8:16:8:16-copy-20" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-20" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Mediawiki.Neutral.Hover-copy-2-+-Imported-Layers-Copy-5" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -184,7 +184,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:checked-/-!default" transform="translate(480)">
-						<text id="Neutral-point" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Neutral-point" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="23">Neutral point</tspan>
 						</text>
 						<g id="Mediawiki.Neutral.Hover-copy-8-+-Imported-Layers-Copy" fill-rule="evenodd" stroke-width="1" transform="translate(0 5)">
@@ -195,13 +195,13 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:disabled" transform="translate(192 226)">
-						<text id="8:16:8:16-copy-17" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-17" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<path id="Mediawiki.Neutral.Hover-copy-11" fill="#C8CCD1" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1" d="M2.005 3.5h19.99A2.505 2.505 0 0124.5 6.005v19.99a2.505 2.505 0 01-2.505 2.505H2.005A2.505 2.505 0 01-.5 25.995V6.005A2.505 2.505 0 012.005 3.5z"/>
 					</g>
 					<g id="Checkbox-/-:active" transform="translate(192 113)">
-						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Mediawiki.Neutral.Hover-copy-15">
@@ -211,13 +211,13 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:hover" transform="translate(192 57)">
-						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<rect id="Mediawiki.Neutral.Hover-copy-13" width="25" height="25" x="-.5" y="3.5" stroke="#2962CC" stroke-width="1" rx="2"/>
 					</g>
 					<g id="Checkbox-/-:focus" transform="translate(192 169)">
-						<text id="8:16:8:16-copy-18" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-18" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Mediawiki.Neutral.Hover-copy-16" stroke="#36C" stroke-width="1">
@@ -226,7 +226,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-!default" transform="translate(192 1)">
-						<text id="8:16:8:16-copy-15" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-15" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Checkbox-:normal" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" transform="translate(0 4)">

--- a/img/components/dropdowns_intro.svg
+++ b/img/components/dropdowns_intro.svg
@@ -12,7 +12,7 @@
 			<g id="DROPDOWN" transform="translate(7998 186)">
 				<g id="Dropdown-X" transform="translate(2 70)">
 					<rect id="Mediawiki.Neutral.Acive-15" width="110" height="33" x="191.5" y="-.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
-					<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="207" y="22">Neutral</tspan>
 					</text>
 					<g id="Icon-/-Dropdown-indicator-/-!default" fill="#222" transform="translate(273 13)">

--- a/img/components/dropdowns_states.svg
+++ b/img/components/dropdowns_states.svg
@@ -115,16 +115,16 @@
 						<path fill="#FFF" stroke="#A2A9B1" d="M191.5 200.443h110v60.508a2.506 2.506 0 01-2.509 2.492H194.01a2.497 2.497 0 01-2.509-2.492v-60.508z"/>
 					</g>
 					<rect id="Mediawiki.Neutral.Acive-15" width="110" height="33" x="191.5" y="-.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
-					<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="207" y="22">Neutral</tspan>
 					</text>
-					<text id="Neutral-26" fill="#444" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Neutral-26" fill="#444" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="207" y="78">Neutral</tspan>
 					</text>
-					<text id="Neutral-26" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Neutral-26" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="207" y="134">Neutral</tspan>
 					</text>
-					<text id="Neutral-26" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Neutral-26" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="207" y="190">Neutral</tspan>
 					</text>
 					<g id="Icon-/-Dropdown-indicator-/-!default" fill="#222" transform="translate(273 13)">
@@ -137,14 +137,14 @@
 						<rect width="111" height="33" x="191.5" y="298.5" rx="2"/>
 						<rect width="109" height="31" x="192.5" y="299.5" stroke-linejoin="square" rx="2"/>
 					</g>
-					<text id="Neutral-26-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Neutral-26-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="207" y="321">Neutral</tspan>
 					</text>
 					<g id="Icon-/-Dropdown-indicator-/-!default" fill="#222" transform="translate(273 312)">
 						<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 					</g>
 					<rect id="Mediawiki.Neutral.Acive-19" width="110" height="33" x="191.5" y="353.5" fill="#C8CCD1" stroke="#C8CCD1" rx="2"/>
-					<text id="Neutral" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Neutral" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="207" y="376">Neutral</tspan>
 					</text>
 					<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(273 368)">
@@ -183,10 +183,10 @@
 					<g id="101-/-8-sp-(0.5-em)" stroke="#50E3C2" stroke-width="4" transform="translate(264 182)">
 						<path id="8-sp-(0.5-em)" d="M0 2h8"/>
 					</g>
-					<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="207" y="221">Neutral</tspan>
 					</text>
-					<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="208" y="253">Neutral 2</tspan>
 					</text>
 					<g id="Mediawiki.Neutral.Acive-15-Copy-5">
@@ -198,16 +198,16 @@
 						<path fill="#FFF" stroke-linejoin="square" d="M452.5 199.5h108v-29.498c0-.832-.671-1.502-1.509-1.502H454.01a1.5 1.5 0 00-1.509 1.502V199.5z"/>
 						<path d="M454.009 167.5H558.99a2.501 2.501 0 012.509 2.502V200.5h-110v-30.498a2.5 2.5 0 012.509-2.502z"/>
 					</g>
-					<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="464.152" y="190">Neutral</tspan>
 					</text>
 					<g id="Icon-/-Dropdown-indicator-/-:active" fill="#000" transform="translate(527 181)">
 						<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 					</g>
-					<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="468" y="222">Neutral</tspan>
 					</text>
-					<text id="Neutral-2" fill="#36C" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Neutral-2" fill="#36C" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="468" y="251">Neutral 2</tspan>
 					</text>
 					<g id="101-/-8-sp-(0.5-em)" stroke="#50E3C2" stroke-width="4" transform="rotate(90 12 204)">
@@ -236,16 +236,16 @@
 							<path fill="#FFF" stroke="#A2A9B1" d="M-.5 32.443h110v60.508a2.506 2.506 0 01-2.509 2.492H2.01A2.497 2.497 0 01-.5 92.951V32.443z"/>
 						</g>
 						<path id="Rectangle-631" fill="#EAECF0" fill-rule="evenodd" d="M0 65h109v29.002c0 .551-.44.998-1.01.998H1.01C.451 95 0 94.553 0 94.002V65z"/>
-						<text id="Neutral-26-Copy-2" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="Neutral-26-Copy-2" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="15" y="23">Neutral</tspan>
 						</text>
 						<g id="Icon-/-Dropdown-indicator-/-!default" fill="#222" fill-rule="evenodd" transform="translate(78 13)">
 							<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 						</g>
-						<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+						<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 							<tspan x="16" y="54">Neutral</tspan>
 						</text>
-						<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+						<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 							<tspan x="16" y="85">Neutral 2</tspan>
 						</text>
 						<circle id="Oval-243-Copy" cx="8.5" cy="49.5" r="2.5" fill="#36C" fill-rule="evenodd"/>
@@ -257,7 +257,7 @@
 						</g>
 					</g>
 					<circle id="Oval-243-Copy-2" cx="460.5" cy="215.5" r="2.5" fill="#36C"/>
-					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="0" y="20">Normal</tspan> <tspan x="0" y="76.1">Hover</tspan> <tspan x="0" y="132.2">Active</tspan> <tspan x="0" y="188.3">Expanded Menu</tspan> <tspan x="0" y="207">Focus</tspan> <tspan x="0" y="319.2">Focus</tspan> <tspan x="0" y="375.3">Disabled</tspan>
 					</text>
 				</g>

--- a/img/components/file_inputs_intro.svg
+++ b/img/components/file_inputs_intro.svg
@@ -4,7 +4,7 @@
 		<g transform="translate(1 1)">
 			<rect width="459" height="31" x=".5" y=".5" fill="#FFF" stroke="#A2A9B1" rx="2"/>
 			<path fill="#F8F9FA" stroke="#A2A9B1" d="M345.5 31.5V.5h112.504c.827 0 1.496.672 1.496 1.502v27.996c0 .834-.667 1.502-1.496 1.502H345.5z"/>
-			<text fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="358" y="23">Select a file</tspan>
 			</text>
 		</g>

--- a/img/components/links_intro.svg
+++ b/img/components/links_intro.svg
@@ -32,7 +32,7 @@
 				<g id="Link-X" transform="translate(2 85)">
 					<g id="Link-:hover" transform="translate(192 408)">
 						<g id="Link">
-							<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="0" y="16">Neutral point</tspan>
 							</text>
 							<path id="Line" stroke="#36C" stroke-linecap="square" d="M1.5 18.5h57.46"/>

--- a/img/components/links_states.svg
+++ b/img/components/links_states.svg
@@ -98,29 +98,29 @@
 			<path fill="#FFF" d="M0 0h14720v3264H0z"/>
 			<g id="LINK" transform="translate(4078 186)">
 				<g id="Link-X" transform="translate(2 76)">
-					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="0" y="16">Normal</tspan> <tspan x="0" y="72.1">Hover</tspan> <tspan x="0" y="90.8"> </tspan> <tspan x="0" y="128.2">Active</tspan> <tspan x="0" y="184.3">Focus</tspan> <tspan x="0" y="240.4">Disabled</tspan>
 					</text>
-					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="0" y="367.3">Normal</tspan> <tspan x="0" y="423.4">Hover</tspan> <tspan x="0" y="442.1"> </tspan> <tspan x="0" y="479.5">Active</tspan> <tspan x="0" y="535.6">Focus</tspan>
 					</text>
 					<g id="101-/-Headline--Sub" transform="translate(0 297)">
-						<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+						<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 							<tspan x="0" y="13">UNDERLINED LINK</tspan>
 						</text>
 						<g id="101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
 							<path id="Line" d="M189.484 1.5H.516"/>
 						</g>
 					</g>
-					<text id="8:16:8:16-copy-5" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16-copy-5" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="192" y="239">Neutral point</tspan>
 					</text>
-					<text id="8:16:8:16-copy" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16-copy" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="192" y="71">Neutral point</tspan>
 					</text>
 					<g id="Link-:hover" transform="translate(192 111)">
 						<g id="Link">
-							<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="0" y="16">Neutral point</tspan>
 							</text>
 							<path id="Line" stroke="#36C" stroke-linecap="square" d="M1.5 18.5h57.46"/>
@@ -129,7 +129,7 @@
 					</g>
 					<g id="Link-:active" transform="translate(192 167)">
 						<g id="Link">
-							<text id="8:16:8:16-copy-3" fill="#2A4B8D" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="8:16:8:16-copy-3" fill="#2A4B8D" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="0" y="16">Neutral point</tspan>
 							</text>
 							<path id="Line" stroke="#2A4B8D" stroke-linecap="square" d="M1.5 18.5h57.46"/>
@@ -137,14 +137,14 @@
 						</g>
 					</g>
 					<g id="Link" transform="translate(192)">
-						<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="0" y="16">Neutral point</tspan>
 						</text>
 						<path id="Line" stroke="#36C" stroke-linecap="square" stroke-width="1" d="M1.5 18.5h57.46"/>
 						<path id="Line-Copy-62" stroke="#36C" stroke-linecap="square" stroke-width="1" d="M65.5 18.5h33"/>
 					</g>
 					<g id="Link" transform="translate(192 352)">
-						<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="0" y="16">Neutral point</tspan>
 						</text>
 						<path id="Line" stroke="#36C" stroke-linecap="square" stroke-width="1" d="M1.5 18.5h57.46"/>
@@ -152,7 +152,7 @@
 					</g>
 					<g id="Link-:hover" transform="translate(192 408)">
 						<g id="Link">
-							<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="0" y="16">Neutral point</tspan>
 							</text>
 							<path id="Line" stroke="#36C" stroke-linecap="square" d="M1.5 18.5h57.46"/>
@@ -161,7 +161,7 @@
 					</g>
 					<g id="Link-:active" transform="translate(192 464)">
 						<g id="Link">
-							<text id="8:16:8:16-copy-3" fill="#2A4B8D" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="8:16:8:16-copy-3" fill="#2A4B8D" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="0" y="16">Neutral point</tspan>
 							</text>
 							<path id="Line" stroke="#2A4B8D" stroke-linecap="square" d="M1.5 18.5h57.46"/>
@@ -169,7 +169,7 @@
 						</g>
 					</g>
 					<g id="Link" transform="translate(192 520)">
-						<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="0" y="16">Neutral point</tspan>
 						</text>
 						<path id="Line" stroke="#36C" stroke-linecap="square" stroke-width="1" d="M1.5 18.5h57.46"/>

--- a/img/components/messages_error.svg
+++ b/img/components/messages_error.svg
@@ -8,8 +8,8 @@
 			<g id="MESSAGES" transform="translate(6147 1464)">
 				<g id="Error-block" transform="translate(184 87)">
 					<path id="Rectangle_fill6" fill="#FEE7E6" fill-rule="nonzero" stroke="#D33" d="M1.5.5v74h699.001V.5H1.5z"/>
-					<text id="An-error-which-means" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-						<tspan x="54" y="28">An error </tspan> <tspan font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">which means</tspan> it&apos;s potentially stopping whatever the user just did <tspan font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">and </tspan> <tspan x="54" y="51" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">providing them a </tspan> <tspan x="178.496" y="51">clear message on what&apos;s wrong. </tspan> <tspan x="429.728" y="51" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">There&apos;s also an </tspan> <tspan x="542.64" y="51" text-decoration="underline">explanatory link</tspan> <tspan x="663.488" y="51">.</tspan>
+					<text id="An-error-which-means" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+						<tspan x="54" y="28">An error </tspan> <tspan font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">which means</tspan> it&apos;s potentially stopping whatever the user just did <tspan font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">and </tspan> <tspan x="54" y="51" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">providing them a </tspan> <tspan x="178.496" y="51">clear message on what&apos;s wrong. </tspan> <tspan x="429.728" y="51" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">There&apos;s also an </tspan> <tspan x="542.64" y="51" text-decoration="underline">explanatory link</tspan> <tspan x="663.488" y="51">.</tspan>
 					</text>
 					<g id="Stop-icon" transform="translate(22 11)">
 						<path id="Polygon" fill="#D33" d="M14 3.05l7.071 2.928L24 13.05l-2.929 7.07L14 23.05l-7.071-2.93L4 13.05l2.929-7.072z" transform="rotate(22.33 14 13.05)"/>

--- a/img/components/messages_notice.svg
+++ b/img/components/messages_notice.svg
@@ -8,8 +8,8 @@
 			<g id="MESSAGES" transform="translate(6147 1464)">
 				<g id="message_notice" transform="translate(185 879)">
 					<path id="Rectangle_fill6" fill="#EAECF0" fill-rule="nonzero" stroke="#C8CCD1" d="M.5.5v73h699.001V.5H.5z"/>
-					<text id="A-neutral-message-wh" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-						<tspan x="53" y="28.943">A neutral message <tspan font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400"> which informs about general higher priority notices to the user. </tspan></tspan> <tspan x="53" y="52.943" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400">Stay neutral!</tspan>
+					<text id="A-neutral-message-wh" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+						<tspan x="53" y="28.943">A neutral message <tspan font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400"> which informs about general higher priority notices to the user. </tspan></tspan> <tspan x="53" y="52.943" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400">Stay neutral!</tspan>
 					</text>
 					<g id="infoFilled" fill="#000" fill-rule="nonzero" transform="translate(25 15.343)">
 						<path id="Shape" d="M10 20.571c-5.523 0-10-4.604-10-10.285S4.477 0 10 0s10 4.605 10 10.286c0 5.68-4.477 10.285-10 10.285zM9 9.257v6.172h2V9.257H9zM10 7.2c.552 0 1-.46 1-1.029 0-.568-.448-1.028-1-1.028s-1 .46-1 1.028C9 6.74 9.448 7.2 10 7.2z"/>

--- a/img/components/messages_success.svg
+++ b/img/components/messages_success.svg
@@ -8,8 +8,8 @@
 			<g id="MESSAGES" transform="translate(6147 1464)">
 				<g id="message-success" transform="translate(185 615)">
 					<path id="Rectangle_fill6" fill="#D5FDF4" fill-rule="nonzero" stroke="#00AF89" d="M.5.5v73h699.001V.5H.5z"/>
-					<text id="A-success-message-wh" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-						<tspan x="53" y="29">A success message</tspan> <tspan font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400"> which means </tspan> <tspan>the user did everything right </tspan> <tspan font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400">and should know </tspan> <tspan x="53" y="53" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400">about it. Yay!</tspan>
+					<text id="A-success-message-wh" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+						<tspan x="53" y="29">A success message</tspan> <tspan font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400"> which means </tspan> <tspan>the user did everything right </tspan> <tspan font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400">and should know </tspan> <tspan x="53" y="53" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400">about it. Yay!</tspan>
 					</text>
 					<path id="Path" fill="#14866D" fill-rule="nonzero" d="M33 32.17L28.83 28l-1.41 1.41L33 35l12-12-1.41-1.42z"/>
 				</g>

--- a/img/components/messages_warning.svg
+++ b/img/components/messages_warning.svg
@@ -9,8 +9,8 @@
 				<g id="message_warning" transform="translate(185 351)">
 					<path id="Rectangle_fill6" fill="#FEF6E7" fill-rule="nonzero" stroke="#FC3" d="M.5.5v73h699.001V.5H.5z"/>
 					<path id="Shape" fill="#FC3" fill-rule="nonzero" d="M44.638 32.15l-8.11-14.06a1.85 1.85 0 00-1.53-1.09 1.85 1.85 0 00-1.52 1.09l-8.12 14.06c-.84 1.45-.15 2.64 1.52 2.64h16.24c1.67 0 2.36-1.19 1.52-2.64zm-8.64-.36h-2v-2h2v2zm0-4h-2v-6h2v6z"/>
-					<text id="A-warning-which-is-n" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-						<tspan x="53" y="29">A warning</tspan> <tspan font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400"> which is not stopping whatever the user just did, but needs to clear up </tspan> <tspan x="53" y="53" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400">why things might not work as expected. </tspan>
+					<text id="A-warning-which-is-n" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+						<tspan x="53" y="29">A warning</tspan> <tspan font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400"> which is not stopping whatever the user just did, but needs to clear up </tspan> <tspan x="53" y="53" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400">why things might not work as expected. </tspan>
 					</text>
 				</g>
 			</g>

--- a/img/components/number_inputs_intro.svg
+++ b/img/components/number_inputs_intro.svg
@@ -9,7 +9,7 @@
 			<rect width="159" height="31" x=".5" y=".5" fill="#F8F9FA" stroke="#A2A9B1" rx="2" transform="translate(200 114)"/>
 			<rect width="95" height="31" x=".5" y=".5" fill="#FFF" stroke="#9AA0A7" rx="2" transform="translate(233 114)"/>
 			<path fill="#FFF" d="M234 141h4v4h-4zm88 0h4v4h-4zm0-26h4v4h-4zm-88 0h4v4h-4z"/>
-			<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="249" y="137">100</tspan>
 			</text>
 			<g transform="translate(207 120)">

--- a/img/components/password_inputs_intro.svg
+++ b/img/components/password_inputs_intro.svg
@@ -5,7 +5,7 @@
 			<rect width="271" height="31" x="193.5" y="151.5" fill="#FFF" stroke-linejoin="square" rx="2"/>
 			<rect width="273" height="33" x="192.5" y="150.5" rx="2"/>
 		</g>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(-188 -146)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(-188 -146)">
 			<tspan x="202" y="174">******</tspan>
 		</text>
 		<path stroke="#000" stroke-linecap="square" d="M50 12.5v17.938"/>

--- a/img/components/radio_buttons_intro_off.svg
+++ b/img/components/radio_buttons_intro_off.svg
@@ -12,7 +12,7 @@
 			<g id="RADIO-BUTTONS---DESKTOP" transform="translate(5840 143)">
 				<g id="Radio-Buttons-X" transform="translate(0 113)">
 					<g id="Radio-/-!default" transform="translate(192)">
-						<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<path id="Oval-112-Copy-2" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" d="M12 28.5C5.096 28.5-.5 22.904-.5 16S5.096 3.5 12 3.5 24.5 9.096 24.5 16 18.904 28.5 12 28.5z"/>

--- a/img/components/radio_buttons_intro_on.svg
+++ b/img/components/radio_buttons_intro_on.svg
@@ -12,13 +12,13 @@
 			<g id="RADIO-BUTTONS---DESKTOP" transform="translate(5840 143)">
 				<g id="Radio-Buttons-X" transform="translate(0 113)">
 					<g id="Radio-/-!default" transform="translate(192)">
-						<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<path id="Oval-112-Copy-2" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" d="M12 28.5C5.096 28.5-.5 22.904-.5 16S5.096 3.5 12 3.5 24.5 9.096 24.5 16 18.904 28.5 12 28.5z"/>
 					</g>
 					<g id="Radio-/-:checked-/-!default" transform="translate(480)">
-						<text id="8:16:8:16-copy-25" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-25" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Oval-112-Copy-3-+-Oval-59-Copy-2" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">

--- a/img/components/radio_buttons_states.svg
+++ b/img/components/radio_buttons_states.svg
@@ -120,13 +120,13 @@
 				<g id="Radio-Button-X" transform="translate(0 113)">
 					<g id="Radio-/-:disabled" transform="translate(192 224)">
 						<circle id="Oval-112" cx="12" cy="16" r="12.5" fill="#C8CCD1" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1"/>
-						<text id="8:16:8:16-copy-27" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-27" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 					</g>
 					<g id="Radio-/-:hover" transform="translate(192 56)">
 						<circle id="Oval-112" cx="12" cy="16" r="12.5" stroke="#2962CC" stroke-width="1"/>
-						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 					</g>
@@ -136,15 +136,15 @@
 							<circle cx="12" cy="16" r="12.5" stroke="#2A4B8D"/>
 							<circle cx="12" cy="16" r="11.5" stroke="#2A4B8D" stroke-linejoin="square"/>
 						</g>
-						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 					</g>
-					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="0" y="21"> Normal</tspan> <tspan x="0" y="77.1"> Hover</tspan> <tspan x="0" y="133.2"> Active</tspan> <tspan x="0" y="189.3"> Focus</tspan> <tspan x="0" y="245.4">Disabled</tspan>
 					</text>
 					<g id="Radio-/-:checked-/-:disabled" transform="translate(480 224)">
-						<text id="8:16:8:16-copy-24" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-24" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Oval-112-Copy-+-Oval-59-Copy" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -153,7 +153,7 @@
 						</g>
 					</g>
 					<g id="Radio-/-!default" transform="translate(192)">
-						<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<path id="Oval-112-Copy-2" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" d="M12 28.5C5.096 28.5-.5 22.904-.5 16S5.096 3.5 12 3.5 24.5 9.096 24.5 16 18.904 28.5 12 28.5z"/>
@@ -170,7 +170,7 @@
 						</g>
 					</g>
 					<g id="Radio-/-:focus" transform="translate(192 168)">
-						<text id="8:16:8:16-copy-23" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-23" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Oval-112-Copy-4" stroke="#36C" stroke-width="1">
@@ -179,7 +179,7 @@
 						</g>
 					</g>
 					<g id="Radio-/-:checked-/-:focus" transform="translate(480 168)">
-						<text id="8:16:8:16-copy-26" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-26" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Oval-112-Copy-5-+-Oval-78" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -192,7 +192,7 @@
 						</g>
 					</g>
 					<g id="Radio-/-:checked-/-:active" transform="translate(480 112)">
-						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Oval-112-Copy-6-+-Oval-59-Copy-3" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -201,7 +201,7 @@
 						</g>
 					</g>
 					<g id="Radio-/-:checked-/-:hover" transform="translate(480 56)">
-						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-16" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Oval-112-+-Oval-59" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -210,7 +210,7 @@
 						</g>
 					</g>
 					<g id="Radio-/-:checked-/-!default" transform="translate(480)">
-						<text id="8:16:8:16-copy-25" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="8:16:8:16-copy-25" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="33" y="22">Neutral point</tspan>
 						</text>
 						<g id="Oval-112-Copy-3-+-Oval-59-Copy-2" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">

--- a/img/components/search_inputs_intro.svg
+++ b/img/components/search_inputs_intro.svg
@@ -2,7 +2,7 @@
 	<g fill="none" fill-rule="evenodd">
 		<path fill="#FFF" d="M-7552-589H7168v3264H-7552z"/>
 		<path fill="#FFF" stroke="#A2A9B1" d="M2.995 1.5c-.828 0-1.495.668-1.495 1.502v27.996c0 .83.67 1.502 1.495 1.502h268.01c.828 0 1.495-.668 1.495-1.502V3.002c0-.83-.67-1.502-1.495-1.502H2.995z"/>
-		<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(-192 -38)">
+		<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(-192 -38)">
 			<tspan x="230" y="61">Search</tspan>
 		</text>
 		<path fill="#222" fill-rule="nonzero" d="M17.5 20c3.04 0 5.5-2.46 5.5-5.5S20.54 9 17.5 9 12 11.46 12 14.5s2.46 5.5 5.5 5.5zm4.55.46A7.432 7.432 0 0117.5 22c-4.14 0-7.5-3.36-7.5-7.5 0-4.14 3.36-7.5 7.5-7.5 4.14 0 7.5 3.36 7.5 7.5 0 1.71-.57 3.29-1.54 4.55l6.49 6.49-1.41 1.41-6.49-6.49z"/>

--- a/img/components/text_inputs.svg
+++ b/img/components/text_inputs.svg
@@ -26,7 +26,7 @@
 		</text>
 		<g transform="translate(194 457)">
 			<rect width="273" height="33" x="-.5" y="-.5" fill="#FFF" stroke="#72777D" rx="2"/>
-			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="32" y="22">Re-enter password</tspan>
 			</text>
 			<path fill="#000" d="M158.584 17.052v7.911c-.009.632-.455 1.335-1.203 2.047a9.12 9.12 0 01-1.222.975l-.026.017a.284.284 0 00-.086.396.295.295 0 00.403.085 9.725 9.725 0 00.42-.294 9.78 9.78 0 00.917-.767c.479-.456.853-.915 1.09-1.373.238.461.61.919 1.088 1.373a9.776 9.776 0 001.337 1.061.295.295 0 00.403-.085.284.284 0 00-.086-.396l-.026-.017a8.2 8.2 0 01-.361-.254 9.168 9.168 0 01-.861-.72c-.748-.713-1.194-1.416-1.203-2.03v-7.93h1.343a.29.29 0 00.291-.286.29.29 0 00-.291-.287h-1.343V8.567c0-.627.447-1.338 1.203-2.055a9.048 9.048 0 011.22-.967l.026-.016a.284.284 0 00.089-.397.294.294 0 00-.403-.087 9.3 9.3 0 00-.421.292 9.667 9.667 0 00-.917.762c-.478.454-.852.912-1.09 1.37-.236-.458-.61-.916-1.089-1.37a9.52 9.52 0 00-1.337-1.054.295.295 0 00-.403.087.284.284 0 00.089.397l.025.016c.023.014.049.032.078.052a9.048 9.048 0 011.144.916c.755.716 1.202 1.427 1.202 2.054v7.91h-1.5a.29.29 0 00-.292.288c0 .158.13.287.292.287h1.5"/>
@@ -36,7 +36,7 @@
 			<rect width="271" height="31" x="195.5" y="208.5" fill="#FFF" stroke-linejoin="square" rx="2"/>
 			<rect width="273" height="33" x="194.5" y="207.5" rx="2"/>
 		</g>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(-1 305)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(-1 305)">
 			<tspan x="226" y="231">******</tspan>
 		</text>
 		<path stroke="#000" stroke-linecap="square" d="M260.5 520.5v17.938"/>
@@ -44,13 +44,13 @@
 		<path fill="#000" d="M219.998 535.998l-5.15-5.15a7 7 0 10-2 2l5.15 5.15 2-2zm-15.5-9a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0z"/>
 		<path stroke="#50E3C2" stroke-linecap="square" d="M457.5 528.5h7m-7-1h7m-7 3h7m-7-1h7"/>
 		<path fill="#FFF" stroke="#9AA0A7" d="M195.995 400.5h268.01a2.498 2.498 0 012.495 2.502v27.996a2.494 2.494 0 01-2.495 2.502h-268.01a2.498 2.498 0 01-2.495-2.502v-27.996a2.494 2.494 0 012.495-2.502z"/>
-		<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(-1 305)">
+		<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(-1 305)">
 			<tspan x="227" y="118">Re-enter password</tspan>
 		</text>
 		<path fill="#222" d="M219.998 423.998l-5.15-5.15a7 7 0 10-2 2l5.15 5.15 2-2zm-15.5-9a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0z"/>
 		<g transform="translate(193 345)">
 			<rect width="273" height="33" x="-.5" y="-.5" stroke="#949494" rx="2"/>
-			<text fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-size="16.364">
+			<text fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16.364">
 				<tspan x="33" y="22">Re-enter password</tspan>
 			</text>
 			<path fill="#949494" d="M26.998 22.998l-5.15-5.15a7 7 0 10-2 2l5.15 5.15 2-2zm-15.5-9a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0z"/>
@@ -62,13 +62,13 @@
 		<path stroke="#222" stroke-linecap="square" d="M190.484 328.5H1.516"/>
 		<g transform="translate(193 9)">
 			<rect width="273" height="33" x="-.5" y="-.5" fill="#EAECF0" stroke="#C8CCD1" rx="2"/>
-			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="16" y="22">Placeholder text</tspan>
 			</text>
 		</g>
 		<g transform="translate(193 121)">
 			<rect width="273" height="33" x="-.5" y="-.5" fill="#FFF" stroke="#72777D" rx="2"/>
-			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="15" y="22">Re-enter password</tspan>
 			</text>
 			<path fill="#000" d="M216.584 28.052v7.911c-.009.632-.455 1.335-1.203 2.047a9.12 9.12 0 01-1.222.975l-.026.017a.284.284 0 00-.086.396.295.295 0 00.403.085 9.725 9.725 0 00.42-.294 9.78 9.78 0 00.917-.767c.479-.456.853-.915 1.09-1.373.238.461.61.919 1.088 1.373a9.776 9.776 0 001.337 1.061.295.295 0 00.403-.085.284.284 0 00-.086-.396l-.026-.017a8.2 8.2 0 01-.361-.254 9.168 9.168 0 01-.861-.72c-.748-.713-1.194-1.416-1.203-2.03v-7.93h1.343a.29.29 0 00.291-.286.29.29 0 00-.291-.287h-1.343v-7.911c0-.627.447-1.338 1.203-2.055a9.048 9.048 0 011.22-.967l.026-.016a.284.284 0 00.089-.397.294.294 0 00-.403-.087 9.3 9.3 0 00-.421.292 9.667 9.667 0 00-.917.762c-.478.454-.852.912-1.09 1.37-.236-.458-.61-.916-1.089-1.37a9.52 9.52 0 00-1.337-1.054.295.295 0 00-.403.087.284.284 0 00.089.397l.025.016c.023.014.049.032.078.052a9.048 9.048 0 011.144.916c.755.716 1.202 1.427 1.202 2.054v7.91h-1.5a.29.29 0 00-.292.288c0 .158.13.287.292.287h1.5"/>
@@ -77,7 +77,7 @@
 			<rect width="273" height="33" x="-.5" y="-.5" rx="2"/>
 			<rect width="271" height="31" x=".5" y=".5" stroke-linejoin="square" rx="2"/>
 		</g>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(193 177)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(193 177)">
 			<tspan x="15" y="21">******</tspan>
 		</text>
 		<path stroke="#000" stroke-linecap="square" d="M242.5 183.5v17.938"/>
@@ -85,7 +85,7 @@
 		<path fill="#000" d="M409.584 205.052v7.911c-.009.632-.455 1.335-1.203 2.047a9.12 9.12 0 01-1.222.975l-.026.017a.284.284 0 00-.086.396.295.295 0 00.403.085 9.725 9.725 0 00.42-.294 9.78 9.78 0 00.917-.767c.479-.456.853-.915 1.09-1.373.238.461.61.919 1.088 1.373a9.776 9.776 0 001.337 1.061.295.295 0 00.403-.085.284.284 0 00-.086-.396l-.026-.017a8.2 8.2 0 01-.361-.254 9.168 9.168 0 01-.861-.72c-.748-.713-1.194-1.416-1.203-2.03v-7.93h1.343a.29.29 0 00.291-.286.29.29 0 00-.291-.287h-1.343v-7.911c0-.627.447-1.338 1.203-2.055a9.048 9.048 0 011.22-.967l.026-.016a.284.284 0 00.089-.397.294.294 0 00-.403-.087 9.3 9.3 0 00-.421.292 9.667 9.667 0 00-.917.762c-.478.454-.852.912-1.09 1.37-.236-.458-.61-.916-1.089-1.37a9.52 9.52 0 00-1.337-1.054.295.295 0 00-.403.087.284.284 0 00.089.397l.025.016c.023.014.049.032.078.052a9.048 9.048 0 011.144.916c.755.716 1.202 1.427 1.202 2.054v7.91h-1.5a.29.29 0 00-.292.288c0 .158.13.287.292.287h1.5"/>
 		<g transform="translate(193 65)">
 			<rect width="273" height="33" x="-.5" y="-.5" fill="#FFF" stroke="#9AA0A7" rx="2"/>
-			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="15" y="22">Re-enter password</tspan>
 			</text>
 		</g>

--- a/img/components/text_inputs_designing.svg
+++ b/img/components/text_inputs_designing.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="274" height="34" viewBox="0 0 274 34">
 	<g fill="none" fill-rule="evenodd">
 		<path fill="#FFF" stroke="#9AA0A7" d="M2.995.5h268.01a2.498 2.498 0 012.495 2.502v27.996a2.494 2.494 0 01-2.495 2.502H2.995A2.498 2.498 0 01.5 30.998V3.002A2.494 2.494 0 012.995.5z"/>
-		<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(0 1)">
+		<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(0 1)">
 			<tspan x="35" y="22">Placeholder text</tspan>
 		</text>
 		<path fill="#222" d="M259 11c-3.3 0-6 2.7-6 6s2.7 6 6 6 6-2.7 6-6-2.7-6-6-6zm3 8.25l-.75.75-2.25-2.25-2.25 2.25-.75-.75 2.25-2.25-2.25-2.25.75-.75 2.25 2.25 2.25-2.25.75.75-2.25 2.25 2.25 2.25z"/>

--- a/img/components/text_inputs_intro.svg
+++ b/img/components/text_inputs_intro.svg
@@ -3,7 +3,7 @@
 		<path fill="#FFF" d="M-7551-255H7169v3264H-7551z"/>
 		<g transform="translate(1 1)">
 			<rect width="271" height="31" x=".5" y=".5" fill="#FFF" stroke="#A2A9B1" rx="2"/>
-			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="9" y="22">Your input</tspan>
 			</text>
 		</g>

--- a/img/components/text_inputs_states.svg
+++ b/img/components/text_inputs_states.svg
@@ -23,13 +23,13 @@
 		<path fill="#FFF" d="M-7359-255H7361v3264H-7359z"/>
 		<g transform="translate(193 169)">
 			<rect width="271" height="31" x=".5" y=".5" fill="#EAECF0" stroke="#C8CCD1" rx="2"/>
-			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="9" y="22">Placeholder text</tspan>
 			</text>
 		</g>
 		<g transform="translate(193 57)">
 			<rect width="271" height="31" x=".5" y=".5" fill="#FFF" stroke="#72777D" rx="2"/>
-			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="9" y="22">Your input</tspan>
 			</text>
 			<path fill="#000" d="M216.584 28.052v7.911c-.009.632-.455 1.335-1.203 2.047a9.12 9.12 0 01-1.222.975l-.026.017a.284.284 0 00-.086.396.295.295 0 00.403.085 9.725 9.725 0 00.42-.294 9.78 9.78 0 00.917-.767c.479-.456.853-.915 1.09-1.373.238.461.61.919 1.088 1.373a9.776 9.776 0 001.337 1.061.295.295 0 00.403-.085.284.284 0 00-.086-.396l-.026-.017a8.2 8.2 0 01-.361-.254 9.168 9.168 0 01-.861-.72c-.748-.713-1.194-1.416-1.203-2.03v-7.93h1.343a.29.29 0 00.291-.286.29.29 0 00-.291-.287h-1.343v-7.911c0-.627.447-1.338 1.203-2.055a9.048 9.048 0 011.22-.967l.026-.016a.284.284 0 00.089-.397.294.294 0 00-.403-.087 9.3 9.3 0 00-.421.292 9.667 9.667 0 00-.917.762c-.478.454-.852.912-1.09 1.37-.236-.458-.61-.916-1.089-1.37a9.52 9.52 0 00-1.337-1.054.295.295 0 00-.403.087.284.284 0 00.089.397l.025.016c.023.014.049.032.078.052a9.048 9.048 0 011.144.916c.755.716 1.202 1.427 1.202 2.054v7.91h-1.5a.29.29 0 00-.292.288c0 .158.13.287.292.287h1.5"/>
@@ -38,7 +38,7 @@
 			<rect width="273" height="33" x="-.5" y="-.5" rx="2"/>
 			<rect width="271" height="31" x=".5" y=".5" stroke-linejoin="square" rx="2"/>
 		</g>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(193 113)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(193 113)">
 			<tspan x="9" y="21">Providing input</tspan>
 		</text>
 		<g transform="translate(440 123)">
@@ -50,7 +50,7 @@
 		<path stroke="#000" stroke-linecap="square" d="M311.5 119.5v17.938"/>
 		<g transform="translate(193 1)">
 			<rect width="271" height="31" x=".5" y=".5" fill="#FFF" stroke="#A2A9B1" rx="2"/>
-			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16">
+			<text fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16">
 				<tspan x="9" y="22">Your input</tspan>
 			</text>
 		</g>
@@ -63,7 +63,7 @@
 			<use filter="url(#text_inputs_states-c)" xlink:href="#text_inputs_states-d"/>
 			<path stroke="#FFF" d="M6.448 11.787l2.721 6.886c.273.675-.094 1.44-.79 1.72-.696.283-1.491-.013-1.765-.692l-2.708-6.853-2.483 2.963-.077.075c-.901.695-1.848.236-1.846-.902L-.474.669c0-.618.027-.82.271-1.028.4-.34.694-.163 1.14.298l10.66 10.157c.793.817.432 1.805-.782 1.933l-4.367-.242z"/>
 		</g>
-		<text fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" transform="translate(1 1)">
+		<text fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" transform="translate(1 1)">
 			<tspan x="0" y="22">Normal</tspan> <tspan x="0" y="78.1">Hover</tspan> <tspan x="0" y="134.2">Focus &amp;</tspan> <tspan x="0" y="152.9">Active</tspan> <tspan x="0" y="190.3">Disabled</tspan>
 		</text>
 	</g>

--- a/img/components/toggle_switch.svg
+++ b/img/components/toggle_switch.svg
@@ -141,16 +141,16 @@
 			<rect width="61" height="33" x="-.5" y="-.5" rx="16.5"/>
 			<circle cx="17" cy="16" r="10.5"/>
 		</g>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" transform="translate(330 477)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" transform="translate(330 477)">
 			<tspan x="0" y="33">Option with a really long</tspan> <tspan x="0" y="53.392">label today</tspan>
 		</text>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" transform="translate(330 477)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" transform="translate(330 477)">
 			<tspan x="0" y="109">Second option</tspan>
 		</text>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(330 477)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(330 477)">
 			<tspan x="0" y="15">Option 1</tspan>
 		</text>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(330 477)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(330 477)">
 			<tspan x="0" y="91">Option 2</tspan>
 		</text>
 		<text fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" transform="translate(0 -11)">
@@ -220,7 +220,7 @@
 			<rect width="61" height="33" x="-.5" y="-.5" rx="16.5"/>
 			<circle cx="17" cy="16" r="10.5"/>
 		</g>
-		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" transform="translate(0 -11)">
+		<text fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" transform="translate(0 -11)">
 			<tspan x="330" y="433">Option 2</tspan>
 		</text>
 		<path fill="#979797" fill-rule="nonzero" d="M328.5 349H320v1h9v-1h-.5zm-8 36.014h8.5v-1h-9v1h.5zM324 349.5v35.514h1V349h-1v.5z"/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -333,6 +333,25 @@
         "color-convert": "^1.9.0"
       }
     },
+    "applause": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/applause/-/applause-1.2.2.tgz",
+      "integrity": "sha1-qEaFeegfZzl7tWNMKZU77c0PVsA=",
+      "dev": true,
+      "requires": {
+        "cson-parser": "^1.1.0",
+        "js-yaml": "^3.3.0",
+        "lodash": "^3.10.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
+      }
+    },
     "arch": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
@@ -1309,6 +1328,23 @@
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "cson-parser": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
+      "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
+      "dev": true,
+      "requires": {
+        "coffee-script": "^1.10.0"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.12.7",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+          "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
           "dev": true
         }
       }
@@ -2505,6 +2541,12 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-sync-cmp": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+      "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
+      "dev": true
+    },
     "file-type": {
       "version": "10.11.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
@@ -3186,6 +3228,60 @@
             "source-map": "^0.6.1",
             "supports-color": "^5.4.0"
           }
+        }
+      }
+    },
+    "grunt-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-replace/-/grunt-replace-1.0.1.tgz",
+      "integrity": "sha1-kKeVMvuJBB/kJ8h9QlI4sPiGZRo=",
+      "dev": true,
+      "requires": {
+        "applause": "1.2.2",
+        "chalk": "^1.1.0",
+        "file-sync-cmp": "^0.1.0",
+        "lodash": "^4.11.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "grunt-eslint": "22.0.0",
     "grunt-exec": "3.0.0",
     "grunt-postcss": "0.9.0",
+    "grunt-replace": "^1.0.1",
     "grunt-sketch": "1.0.5",
     "grunt-stylelint": "0.12.0",
     "grunt-svgmin": "6.0.0",

--- a/resources/WikimediaUI-components_overview.svg
+++ b/resources/WikimediaUI-components_overview.svg
@@ -995,10 +995,10 @@
 		<circle id="path-142" cx="12" cy="16" r="12"/>
 		<circle id="path-143" cx="12" cy="16" r="12"/>
 		<circle id="path-144" cx="12" cy="12" r="12"/>
-		<text id="text-194" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+		<text id="text-194" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 			<tspan x="218.452" y="134">Progressive</tspan>
 		</text>
-		<text id="text-196" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+		<text id="text-196" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 			<tspan x="381.288" y="134">Destructive</tspan>
 		</text>
 		<pattern id="pattern-1" width="48" height="48" x="-48" y="-48" patternUnits="userSpaceOnUse">
@@ -1010,60 +1010,60 @@
 		<g id="WikimediaUI-Color-palette" transform="translate(1757 1421)">
 			<g id="Supplementary" transform="translate(241 776)">
 				<rect id="Rectangle-Copy-15" width="176" height="128" x="1037" y="58" fill="#AC6600" rx="2"/>
-				<text id="#ac6600-RGB-172,-102" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#ac6600-RGB-172,-102" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1055" y="92">#ac6600</tspan> <tspan x="1055" y="111">RGB 172, 102, 0</tspan> <tspan x="1055" y="130">HSB 36, 100%, 67%</tspan> <tspan x="1055" y="168">AA</tspan>
 				</text>
 				<rect id="Rectangle" width="160" height="160" x="878" y="25" fill="#FC3" rx="2"/>
-				<text id="#fc3-RGB-255,-204,-5" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#fc3-RGB-255,-204,-5" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="894" y="92">#fc3</tspan> <tspan x="894" y="111">RGB 255, 204, 51</tspan> <tspan x="894" y="130">HSB 45, 80%, 100%</tspan> <tspan x="894" y="168">AAA</tspan>
 				</text>
 				<path id="Rectangle-Copy-8" fill="#FEF6E7" d="M702 68.008c0-1.11.905-2.008 2.007-2.008h171.986c1.108 0 2.007.897 2.007 2.008v115.984a2.011 2.011 0 01-2.007 2.008H704.007a2.006 2.006 0 01-2.007-2.008V68.008z"/>
-				<text id="#fef6e7-RGB-254,-246" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#fef6e7-RGB-254,-246" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="718" y="92">#fef6e7</tspan> <tspan x="718" y="111">RGB 254, 246, 231</tspan> <tspan x="718" y="130">HSB 39, 9%, 100%</tspan> <tspan x="718" y="168">AAA</tspan>
 				</text>
-				<text id="Yellow50" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Yellow50" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="894" y="14">Yellow50</tspan>
 				</text>
-				<text id="Yellow30" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Yellow30" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1054" y="14">Yellow30</tspan>
 				</text>
 				<rect id="Rectangle-543-Copy" width="160" height="160" x="176" y="25" fill="#00AF89" rx="2"/>
-				<text id="Green50" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Green50" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="191" y="14">Green50</tspan>
 				</text>
-				<text id="Green30" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Green30" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="351" y="14">Green30</tspan>
 				</text>
-				<text id="#00af89-RGB-0,-175," fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#00af89-RGB-0,-175," fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="191" y="92">#00af89</tspan> <tspan x="191" y="111">RGB 0, 175, 137</tspan> <tspan x="191" y="130">HSB 167,100%,69%</tspan> <tspan x="191" y="168">AA</tspan>
 				</text>
 				<rect id="Rectangle-Copy-12" width="176" height="120" x="336" y="65" fill="#14866D" rx="2"/>
 				<rect id="Rectangle-Copy-8" width="176" height="128" x="0" y="57" fill="#D5FDF4" rx="2"/>
-				<text id="#d5fdf4-RGB-213,-253" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#d5fdf4-RGB-213,-253" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="15" y="92">#d5fdf4</tspan> <tspan x="15" y="111">RGB 213, 253, 244</tspan> <tspan x="15" y="130">HSB 167, 16%, 99%</tspan> <tspan x="15" y="168">AAA</tspan>
 				</text>
-				<text id="Yellow90" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Yellow90" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="718" y="14">Yellow90</tspan>
 				</text>
-				<text id="Green90" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Green90" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="15" y="14">Green90</tspan>
 				</text>
-				<text id="#14866d-RGB-20,-134," fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#14866d-RGB-20,-134," fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="351" y="92">#14866d</tspan> <tspan x="351" y="111">RGB 20, 134, 109</tspan> <tspan x="351" y="130">HSB 167, 85%, 53%</tspan> <tspan x="351" y="168">AA</tspan>
 				</text>
-				<text id="Secondary-link-highl" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Secondary-link-highl" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="189" y="223.1">Secondary link highlight</tspan> <tspan x="189" y="241.8">Positive messages</tspan>
 				</text>
-				<text id="Warning-messages" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Warning-messages" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="889" y="223.1">Warning messages</tspan>
 				</text>
 			</g>
 			<g id="Accent">
-				<text id="COLOR" fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+				<text id="COLOR" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 					<tspan x="2" y="36">COLOR</tspan> <tspan x="2" y="80">PALETTE</tspan>
 				</text>
 				<g id="_Spec-101-/-Headline--Sub" transform="translate(4 134)">
-					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 						<tspan x="0" y="13">BASE COLORS</tspan>
 					</text>
 					<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -1074,7 +1074,7 @@
 					<path id="Line" d="M183.5 1.5H.5"/>
 				</g>
 				<g id="_Spec-101-/-Headline--Sub" transform="translate(2 458)">
-					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 						<tspan x="0" y="13">ACCENT COLORS</tspan>
 					</text>
 					<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -1082,166 +1082,166 @@
 					</g>
 				</g>
 				<rect id="Progressive" width="159" height="159" x="416.5" y="482.5" fill="#36C" stroke="#36C" rx="2"/>
-				<text id="Primary-buttons-Link" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Primary-buttons-Link" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="432" y="670.1">Primary buttons</tspan> <tspan x="432" y="688.8">Links </tspan> <tspan x="432" y="707.5">Page accents</tspan> <tspan x="432" y="726.2">Focus outlines</tspan>
 				</text>
-				<text id="Active-buttons-Activ" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Active-buttons-Activ" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="591" y="670.1">Active buttons</tspan> <tspan x="591" y="688.8">Active links </tspan>
 				</text>
 				<rect id="Progressive" width="176" height="120" x="240" y="522" fill="#EAF3FF" rx="2"/>
 				<rect id="Destructive" width="160" height="160" x="1119" y="482" fill="#D33" rx="2"/>
 				<rect id="Destructive" width="176" height="128" x="943" y="514" fill="#FEE7E6" rx="2"/>
-				<text id="Accent30" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Accent30" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="591" y="471">Accent30</tspan>
 				</text>
-				<text id="Progressive-#36c-RGB" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="Progressive-#36c-RGB" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="432" y="510">Progressive</tspan> <tspan x="432" y="548">#36c</tspan> <tspan x="432" y="567">RGB 51, 102, 204</tspan> <tspan x="432" y="586">HSB 220, 75%, 80%</tspan> <tspan x="432" y="624">AA</tspan>
 				</text>
-				<text id="#eaf3ff-RGB-234,-243" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#eaf3ff-RGB-234,-243" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="256" y="548">#eaf3ff</tspan> <tspan x="256" y="567">RGB 234, 243, 255</tspan> <tspan x="256" y="586">HSB 214, 8%, 100%</tspan> <tspan x="256" y="624">AAA</tspan>
 				</text>
-				<text id="Base100" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Base100" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="256" y="147">Base100</tspan>
 				</text>
-				<text id="#fee7e6-RGB-255,-231" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#fee7e6-RGB-255,-231" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="959" y="548">#fee7e6</tspan> <tspan x="959" y="567">RGB 255, 231, 230</tspan> <tspan x="959" y="586">HSB 2, 10%, 100%</tspan> <tspan x="959" y="624">AAA</tspan>
 				</text>
-				<text id="Destructive-#d33-RGB" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="Destructive-#d33-RGB" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1130" y="510">Destructive</tspan> <tspan x="1130" y="548">#d33</tspan> <tspan x="1130" y="567">RGB 221, 51, 51</tspan> <tspan x="1130" y="586">HSB 360, 77%, 87%</tspan> <tspan x="1130" y="624">AA</tspan>
 				</text>
-				<text id="AA" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="AA" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1157" y="624">AA</tspan>
 				</text>
 				<rect id="Rectangle-Copy" width="176" height="128" x="1279" y="514" fill="#B32424" rx="2"/>
-				<text id="#b32424-RGB-135,-54," fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#b32424-RGB-135,-54," fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1295" y="548">#b32424</tspan> <tspan x="1295" y="567">RGB 135, 54, 54</tspan> <tspan x="1295" y="586">HSB 360, 60%, 53%</tspan> <tspan x="1295" y="624">AAA</tspan>
 				</text>
 				<rect id="Rectangle-Copy" width="176" height="120" x="576" y="522" fill="#2A4B8D" rx="2"/>
-				<text id="#2a4b8d-RGB-42,-75," fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#2a4b8d-RGB-42,-75," fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="592" y="548">#2a4b8d</tspan> <tspan x="592" y="567">RGB 42, 75, 141</tspan> <tspan x="592" y="586">HSB 220, 70%, 55%</tspan> <tspan x="592" y="624">AAA</tspan>
 				</text>
-				<text id="Destructive-actions" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Destructive-actions" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="1129" y="671.1">Destructive actions –</tspan> <tspan x="1129" y="689.8">Buttons and Links</tspan> <tspan x="1129" y="708.5">Alerts</tspan>
 				</text>
-				<text id="Destructive-active-b" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Destructive-active-b" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="1295" y="668.1">Destructive active </tspan> <tspan x="1295" y="686.8">buttons and links</tspan>
 				</text>
-				<text id="Hovered-buttons-Acti" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Hovered-buttons-Acti" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="256" y="670.1">Hovered buttons</tspan> <tspan x="256" y="688.8">Active menu </tspan> <tspan x="256" y="707.5">items backgrounds</tspan>
 				</text>
 			</g>
 			<g id="Base" transform="translate(5 133)">
 				<rect id="Rectangle-Copy-8" width="160.001" height="160" x="235" y="25" fill="#FFF" rx="2"/>
-				<text id="Base-background-High" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Base-background-High" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="251" y="214.1">Base background</tspan> <tspan x="251" y="232.8">Highlight from grey</tspan>
 				</text>
-				<text id="Disabled-text-input" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Disabled-text-input" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="603" y="214.1">Disabled text input </tspan> <tspan x="603" y="232.8">background</tspan>
 				</text>
-				<text id="#fff-RGB-255,-255,-2" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#fff-RGB-255,-255,-2" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="251" y="92">#fff</tspan> <tspan x="251" y="111">RGB 255, 255, 255</tspan> <tspan x="251" y="130">HSB 0, 0%, 100%</tspan> <tspan x="251" y="168">AAA</tspan>
 				</text>
-				<text id="Accent90" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Accent90" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="251" y="338">Accent90</tspan>
 				</text>
-				<text id="Accent50" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Accent50" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="426" y="338">Accent50 </tspan>
 				</text>
-				<text id="Red90" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Red90" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="954" y="338">Red90</tspan>
 				</text>
-				<text id="Red50" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Red50" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1130" y="338">Red50</tspan>
 				</text>
-				<text id="Red30" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Red30" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1290" y="338">Red30</tspan>
 				</text>
-				<text id="Base90" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Base90" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="427" y="14">Base90</tspan>
 				</text>
-				<text id="Base80" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Base80" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="603" y="14">Base80</tspan>
 				</text>
-				<text id="Base70" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Base70" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="779" y="14">Base70</tspan>
 				</text>
-				<text id="Base50" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Base50" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="955" y="14">Base50</tspan>
 				</text>
-				<text id="Base30" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Base30" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1131" y="14">Base30</tspan>
 				</text>
-				<text id="Base20" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Base20" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1307" y="14">Base20</tspan>
 				</text>
-				<text id="Base10" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Base10" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1483" y="14">Base10</tspan>
 				</text>
-				<text id="Base0" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="Base0" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1659" y="14">Base0</tspan>
 				</text>
 				<rect id="Rectangle" width="160" height="160" x="411" y="25" fill="#F8F9FA" rx="2"/>
-				<text id="Button/3D-widget-bac" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Button/3D-widget-bac" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="427" y="214.1">Button/3D widget </tspan> <tspan x="427" y="232.8">background</tspan>
 				</text>
-				<text id="#f8f9fa-RGB-248,-249" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#f8f9fa-RGB-248,-249" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="427" y="92">#f8f9fa</tspan> <tspan x="427" y="111">RGB 248, 249, 250</tspan> <tspan x="427" y="130">HSB 210, 1%, 98%</tspan> <tspan x="427" y="168">AAA</tspan>
 				</text>
 				<rect id="Rectangle-Copy" width="160" height="160" x="587" y="25" fill="#EAECF0" rx="2"/>
-				<text id="#eaecf0-RGB-234,-236" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#eaecf0-RGB-234,-236" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="603" y="92">#eaecf0</tspan> <tspan x="603" y="111">RGB 234, 236, 240</tspan> <tspan x="603" y="130">HSB 220, 3%, 94%</tspan> <tspan x="603" y="168">AAA</tspan>
 				</text>
 				<rect id="Rectangle-Copy-2" width="160" height="160" x="763" y="25" fill="#C8CCD1" rx="2"/>
-				<text id="#c8ccd1-RGB-200,-204" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#c8ccd1-RGB-200,-204" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="779" y="92">#c8ccd1</tspan> <tspan x="779" y="111">RGB 200, 204, 209</tspan> <tspan x="779" y="130">HSB 213, 4%, 82%</tspan> <tspan x="779" y="168">AAA</tspan>
 				</text>
 				<rect id="Rectangle-Copy-3" width="160" height="160" x="939" y="25" fill="#A2A9B1" rx="2"/>
-				<text id="#a2a9b1-RGB-162,-169" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#a2a9b1-RGB-162,-169" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="955" y="92">#a2a9b1</tspan> <tspan x="955" y="111">RGB 162, 169, 177</tspan> <tspan x="955" y="130">HSB 212, 8%, 69%</tspan> <tspan x="955" y="168">AAA</tspan>
 				</text>
 				<rect id="Rectangle-Copy-9" width="160" height="160" x="1115" y="25" fill="#72777D" rx="2"/>
-				<text id="#72777d-RGB-114,-119" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#72777d-RGB-114,-119" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1131" y="92">#72777d</tspan> <tspan x="1131" y="111">RGB 114, 119, 125</tspan> <tspan x="1131" y="130">HSB 210, 9%, 49%</tspan> <tspan x="1131" y="168">AA </tspan>
 				</text>
-				<text id="AA" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="AA" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1153" y="168">AA</tspan>
 				</text>
 				<rect id="Rectangle-Copy-6" width="160" height="160" x="1291" y="25" fill="#54595D" rx="2"/>
-				<text id="#54595d-RGB-84,-89," fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#54595d-RGB-84,-89," fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1307" y="92">#54595d</tspan> <tspan x="1307" y="111">RGB 84, 89, 93</tspan> <tspan x="1307" y="130">HSB 207, 10%, 36%</tspan> <tspan x="1307" y="168">AAA</tspan>
 				</text>
 				<rect id="Rectangle-Copy-5" width="160" height="160" x="1467" y="25" fill="#222" rx="2"/>
-				<text id="#222-RGB-34,-34,-34" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#222-RGB-34,-34,-34" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1483" y="92">#222</tspan> <tspan x="1483" y="111">RGB 34, 34, 34</tspan> <tspan x="1483" y="130">HSB 0, 0%, 13%</tspan> <tspan x="1483" y="168">AAA</tspan>
 				</text>
 				<rect id="Rectangle-Copy-7" width="160" height="160" x="1643" y="25" fill="#000" rx="2"/>
-				<text id="#000-RGB-0,-0,-0-HSB" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="#000-RGB-0,-0,-0-HSB" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="1659" y="92">#000</tspan> <tspan x="1659" y="111">RGB 0, 0, 0</tspan> <tspan x="1659" y="130">HSB 0, 0%, 0%</tspan> <tspan x="1659" y="168">AAA</tspan>
 				</text>
-				<text id="Disabled-button/3D-w" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Disabled-button/3D-w" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="779" y="214.1">Disabled button/3D </tspan> <tspan x="779" y="232.8">widget background </tspan>
 				</text>
-				<text id="Highlighted-border" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Highlighted-border" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="955" y="214.1">Highlighted border</tspan>
 				</text>
-				<text id="Disabled-elements-te" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Disabled-elements-te" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="1131" y="213.1">Disabled elements text</tspan> <tspan x="1131" y="231.8">Placeholder text</tspan> <tspan x="1131" y="250.5">Active border</tspan>
 				</text>
-				<text id="Copy-color-Buttons/w" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Copy-color-Buttons/w" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="1483" y="213.1">Copy color</tspan> <tspan x="1483" y="231.8">Buttons/widgets text</tspan>
 				</text>
-				<text id="Emphasized-copy-colo" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Emphasized-copy-colo" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="1659" y="213.1">Emphasized copy color</tspan> <tspan x="1659" y="231.8">Active button/widgets text</tspan>
 				</text>
-				<text id="Emphasized-secondary" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Emphasized-secondary" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="1307" y="213.1">Emphasized secondary </tspan> <tspan x="1307" y="231.8">text at level AAA need</tspan>
 				</text>
-				<text id="WCAG-2.0-conformance" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="WCAG-2.0-conformance" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="168.1">WCAG 2.0 conformance level:</tspan> <tspan x="0" y="186.8">(with white/black)</tspan>
 				</text>
 			</g>
 			<g id="_Spec-101-/-Headline--Sub" transform="translate(2 778)">
-				<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="0" y="13">SUPPLEMENTARY COLORS</tspan>
 				</text>
 				<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -1250,7 +1250,7 @@
 			</g>
 			<g id="Background-colors-applied" transform="translate(5 1098)">
 				<g id="_Spec-101-/-Headline--Sub">
-					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 						<tspan x="0" y="13">BACKGROUND COLORS</tspan>
 					</text>
 					<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -1261,16 +1261,16 @@
 				<rect id="Rectangle-543-Copy-3" width="416" height="256" x="283" y="71" fill="#FFF" rx="2"/>
 				<rect id="Rectangle-543-Copy-4" width="320" height="160" x="331" y="119" fill="#EAECF0" rx="2"/>
 				<path id="Rectangle-543-Copy-5" fill="#C8CCD1" d="M379 169.003c0-1.106.903-2.003 2.005-2.003h219.99a2.01 2.01 0 012.005 2.003v59.994a2.007 2.007 0 01-2.005 2.003h-219.99a2.01 2.01 0 01-2.005-2.003v-59.994z"/>
-				<text id="Layer-1:-#f8f9fa" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="Layer-1:-#f8f9fa" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="435" y="359">Layer 1: #f8f9fa</tspan>
 				</text>
-				<text id="Layer-2:-#fff" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="Layer-2:-#fff" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="435" y="312">Layer 2: #fff</tspan>
 				</text>
-				<text id="Layer-3:-#eaecf0" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="Layer-3:-#eaecf0" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="435" y="264">Layer 3: #eaecf0</tspan>
 				</text>
-				<text id="Layer-4:-#c8ccd1" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
+				<text id="Layer-4:-#c8ccd1" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="435" y="214">Layer 4: #c8ccd1</tspan>
 				</text>
 			</g>
@@ -1282,18 +1282,18 @@
 						<rect id="Mediawiki.Neutral.Hover-35" width="699" height="31" x=".5" y=".5" rx="2"/>
 					</g>
 				</g>
-				<text id="Re-enter-password" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="Re-enter-password" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="14" y="22">Re-enter password</tspan>
 				</text>
 			</g>
 			<g id="Msg-block-sizing" transform="translate(185 1192)">
 				<path id="Rectangle_fill6" fill="url(#pattern-1)" fill-opacity=".05" stroke="#C8CCD1" d="M.5.5v97h699.001V.5H.5z"/>
-				<text id="Multiline-inline-mes" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Multiline-inline-mes" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="40" y="142">Multiline inline message without rich text. Only sentences, which bring clarity on </tspan> <tspan x="40" y="166">what&apos;s happening to the user. </tspan>
 				</text>
 				<path id="Icon-template" fill="#000" fill-rule="nonzero" d="M22 130c-5.523 0-10 4.477-10 10s4.477 10 10 10 10-4.477 10-10a10 10 0 00-10-10z"/>
-				<text id="Multiline-block-mess" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="53" y="25">Multiline block message</tspan> <tspan x="237.768" y="25" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400"> with rich text like </tspan> <tspan x="371.736" y="25" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400" text-decoration="underline">links to Nas</tspan> <tspan x="457.992" y="25" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400">, who </tspan> <tspan x="53" y="49" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400"> • will rule the World and </tspan> <tspan x="53" y="73" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400"> • free all his sons</tspan>
+				<text id="Multiline-block-mess" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="53" y="25">Multiline block message</tspan> <tspan x="237.768" y="25" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400"> with rich text like </tspan> <tspan x="371.736" y="25" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400" text-decoration="underline">links to Nas</tspan> <tspan x="457.992" y="25" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400">, who </tspan> <tspan x="53" y="49" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400"> • will rule the World and </tspan> <tspan x="53" y="73" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400"> • free all his sons</tspan>
 				</text>
 				<g id="Icon-/-placeholder-(notBright/circle)-/-:active" fill="#000" transform="translate(25 13)">
 					<path id="Shape" d="M10 0C4.477 0 0 4.477 0 10s4.477 10 10 10 10-4.477 10-10S15.523 0 10 0z"/>
@@ -1335,30 +1335,30 @@
 				<g id="_Spec-101-/-24-sp-(1.5-em)" stroke="#A65DE7" stroke-width="4" transform="translate(675 140)">
 					<path id="24-sp-(1.5-em)" d="M0 2h24" transform="matrix(1 0 0 -1 0 4)"/>
 				</g>
-				<text id="24-scale-independent" fill="#B800BD" font-family="Lato-Regular, Lato" font-size="16" font-weight="normal">
+				<text id="24-scale-independent" fill="#B800BD" font-family="Lato-Regular, Lato, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="46" y="268">24 scale-independent pixels (1.5 em)</tspan>
 				</text>
-				<text id="20-sp-(1.25-em)" fill="#B800BD" font-family="Lato-Regular, Lato" font-size="16" font-weight="normal">
+				<text id="20-sp-(1.25-em)" fill="#B800BD" font-family="Lato-Regular, Lato, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="46" y="303">20 sp (1.25 em)</tspan>
 				</text>
-				<text id="16-sp-(1-em)" fill="#B800BD" font-family="Lato-Regular, Lato" font-size="16" font-weight="normal">
+				<text id="16-sp-(1-em)" fill="#B800BD" font-family="Lato-Regular, Lato, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="46" y="337">16 sp (1 em)</tspan>
 				</text>
-				<text id="12-sp-(0.75-em)" fill="#B800BD" font-family="Lato-Regular, Lato" font-size="16" font-weight="normal">
+				<text id="12-sp-(0.75-em)" fill="#B800BD" font-family="Lato-Regular, Lato, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="46" y="372">12 sp (0.75 em)</tspan>
 				</text>
-				<text id="8-sp-(0.5-em)" fill="#B800BD" font-family="Lato-Regular, Lato" font-size="16" font-weight="normal">
+				<text id="8-sp-(0.5-em)" fill="#B800BD" font-family="Lato-Regular, Lato, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="46" y="407">8 sp (0.5 em)</tspan>
 				</text>
-				<text id="`font-size:-1em`" fill="#B800BD" font-family="Lato-Regular, Lato" font-size="16" font-weight="normal">
+				<text id="`font-size:-1em`" fill="#B800BD" font-family="Lato-Regular, Lato, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="732" y="32">`font-size: 1em`</tspan>
 				</text>
-				<text id="`font-size:-1em`-`fo" fill="#B800BD" font-family="Lato-Regular, Lato" font-size="16" font-weight="normal">
+				<text id="`font-size:-1em`-`fo" fill="#B800BD" font-family="Lato-Regular, Lato, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="732" y="145">`font-size: 1em`</tspan> <tspan x="732" y="164">`font-weight: bold`</tspan>
 				</text>
 			</g>
 			<g id="Notice_inline" fill="#000" transform="translate(197 973)">
-				<text id="A-neutral-message-wh" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="A-neutral-message-wh" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="29" y="16">A neutral message which informs about general higher priority notices to the user. </tspan> <tspan x="29" y="40">Stay neutral!</tspan>
 				</text>
 				<g id="infoFilled" fill-rule="nonzero" transform="translate(0 4)">
@@ -1367,15 +1367,15 @@
 			</g>
 			<g id="Notice_block" transform="translate(185 879)">
 				<path id="bg-message--notice" fill="#EAECF0" fill-rule="nonzero" stroke="#C8CCD1" d="M.5.5v73h699.001V.5H.5z"/>
-				<text id="A-neutral-message-wh" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="53" y="28.943">A neutral message</tspan> <tspan x="195.192" y="28.943" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400"> which informs about general higher priority notices to the user. </tspan> <tspan x="53" y="52.943" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400">Stay neutral!</tspan>
+				<text id="A-neutral-message-wh" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="53" y="28.943">A neutral message</tspan> <tspan x="195.192" y="28.943" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400"> which informs about general higher priority notices to the user. </tspan> <tspan x="53" y="52.943" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400">Stay neutral!</tspan>
 				</text>
 				<g id="infoFilled" fill="#000" fill-rule="nonzero" transform="translate(25 15.343)">
 					<path id="Shape" d="M10 20.571c-5.523 0-10-4.604-10-10.285S4.477 0 10 0s10 4.605 10 10.286c0 5.68-4.477 10.285-10 10.285zM9 9.257v6.172h2V9.257H9zM10 7.2c.552 0 1-.46 1-1.029 0-.568-.448-1.028-1-1.028s-1 .46-1 1.028C9 6.74 9.448 7.2 10 7.2z"/>
 				</g>
 			</g>
 			<g id="Success_inline_ALT" fill="#14866D" transform="translate(199 709)">
-				<text id="A-success-message-wh" font-family="HelveticaNeue-Medium, Helvetica Neue" font-size="16" font-weight="400">
+				<text id="A-success-message-wh" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-size="16" font-weight="400">
 					<tspan x="27" y="16">A success message which means the user did everything right and should know about </tspan> <tspan x="27" y="36">it. Yay!</tspan>
 				</text>
 				<g id="check" fill-rule="nonzero" transform="translate(0 4)">
@@ -1384,13 +1384,13 @@
 			</g>
 			<g id="Success_block" transform="translate(185 615)">
 				<path id="bg-message--success" fill="#D5FDF4" fill-rule="nonzero" stroke="#00AF89" d="M.5.5v73h699.001V.5H.5z"/>
-				<text id="A-success-message-wh" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="53" y="29">A success message</tspan> <tspan x="204.68" y="29" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400"> which means </tspan> <tspan x="310.792" y="29">the user did everything right </tspan> <tspan x="529.48" y="29" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400">and should know </tspan> <tspan x="53" y="53" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400">about it. Yay!</tspan>
+				<text id="A-success-message-wh" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="53" y="29">A success message</tspan> <tspan x="204.68" y="29" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400"> which means </tspan> <tspan x="310.792" y="29">the user did everything right </tspan> <tspan x="529.48" y="29" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400">and should know </tspan> <tspan x="53" y="53" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400">about it. Yay!</tspan>
 				</text>
 				<path id="Path" fill="#14866D" fill-rule="nonzero" d="M33 32.17L28.83 28l-1.41 1.41L33 35l12-12-1.41-1.42z"/>
 			</g>
 			<g id="Warning_inline" transform="translate(198 445)">
-				<text id="A-warning-which-is-n" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="A-warning-which-is-n" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="28" y="16">A warning which is not stopping whatever the user just did, but needs to clear up </tspan> <tspan x="28" y="36">why things might not work as expected. </tspan>
 				</text>
 				<g id="alert-warning" fill="#FC3" fill-rule="nonzero" transform="translate(0 1)">
@@ -1400,12 +1400,12 @@
 			<g id="Warning_block" transform="translate(185 351)">
 				<path id="bg-message--warning" fill="#FEF6E7" fill-rule="nonzero" stroke="#FC3" d="M.5.5v73h699.001V.5H.5z"/>
 				<path id="Shape" fill="#FC3" fill-rule="nonzero" d="M44.638 32.15l-8.11-14.06a1.85 1.85 0 00-1.53-1.09 1.85 1.85 0 00-1.52 1.09l-8.12 14.06c-.84 1.45-.15 2.64 1.52 2.64h16.24c1.67 0 2.36-1.19 1.52-2.64zm-8.64-.36h-2v-2h2v2zm0-4h-2v-6h2v6z"/>
-				<text id="A-warning-which-is-n" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="53" y="29">A warning</tspan> <tspan x="130.008" y="29" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400"> which is not stopping whatever the user just did, but needs to clear up </tspan> <tspan x="53" y="53" font-family="HelveticaNeue-Medium, Helvetica Neue" font-weight="400">why things might not work as expected. </tspan>
+				<text id="A-warning-which-is-n" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="53" y="29">A warning</tspan> <tspan x="130.008" y="29" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400"> which is not stopping whatever the user just did, but needs to clear up </tspan> <tspan x="53" y="53" font-family="HelveticaNeue-Medium, Helvetica Neue, sans-serif" font-weight="400">why things might not work as expected. </tspan>
 				</text>
 			</g>
 			<g id="Error-inline" transform="translate(192 235)">
-				<text id="An-error-which-means" fill="#D33" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="An-error-which-means" fill="#D33" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="34" y="18">An error which means it&apos;s potentially stopping whatever the user just did and will give </tspan> <tspan x="34" y="38">them a clear message what is wrong. </tspan>
 				</text>
 				<g id="Stop-icon" transform="translate(.05)">
@@ -1419,40 +1419,40 @@
 						<rect id="Mediawiki.Neutral.Hover-35" width="699" height="31" x=".5" y=".5" rx="2"/>
 					</g>
 				</g>
-				<text id="Re-enter-password" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="Re-enter-password" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="14" y="22">Re-enter password</tspan>
 				</text>
 			</g>
 			<g id="Error-block" transform="translate(184 87)">
 				<path id="bg-message--error" fill="#FEE7E6" fill-rule="nonzero" stroke="#D33" d="M1.5.5v74h699.001V.5H1.5z"/>
-				<text id="An-error-which-means" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="54" y="27">An error </tspan> <tspan x="120.688" y="27" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">which means</tspan> <tspan x="214.928" y="27"> it&apos;s potentially stopping whatever the user just did </tspan> <tspan x="603.936" y="27" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">and </tspan> <tspan x="54" y="51" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">providing them a </tspan> <tspan x="178.496" y="51">clear message on what&apos;s wrong. </tspan> <tspan x="429.728" y="51" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">There&apos;s also an </tspan> <tspan x="542.64" y="51" text-decoration="underline">explanatory link</tspan> <tspan x="663.488" y="51">.</tspan>
+				<text id="An-error-which-means" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="54" y="27">An error </tspan> <tspan x="120.688" y="27" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">which means</tspan> <tspan x="214.928" y="27"> it&apos;s potentially stopping whatever the user just did </tspan> <tspan x="603.936" y="27" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">and </tspan> <tspan x="54" y="51" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">providing them a </tspan> <tspan x="178.496" y="51">clear message on what&apos;s wrong. </tspan> <tspan x="429.728" y="51" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">There&apos;s also an </tspan> <tspan x="542.64" y="51" text-decoration="underline">explanatory link</tspan> <tspan x="663.488" y="51">.</tspan>
 				</text>
 				<g id="Stop-icon" transform="translate(22 11)">
 					<path id="Polygon" fill="#D33" d="M14 3.05l7.071 2.928L24 13.05l-2.929 7.071L14 23.05l-7.071-2.929L4 13.05l2.929-7.072z" transform="rotate(22.33 14 13.05)"/>
 					<path id="Path" fill="#FEE7E6" d="M14.95 18h-2v-2h2zM14.95 14h-2V8h2z"/>
 				</g>
 			</g>
-			<text id="Sizes" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Sizes" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="1222"> Sizes</tspan>
 			</text>
-			<text id="Notice" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Notice" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="914"> Notice</tspan>
 			</text>
-			<text id="Success" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Success" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="646"> Success</tspan>
 			</text>
-			<text id="Warning" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Warning" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="382"> Warning</tspan>
 			</text>
-			<text id="Error" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Error" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="118">Error</tspan>
 			</text>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 52)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
 			<path id="horizontal-rule" stroke="#C8CCD1" stroke-linecap="square" stroke-width="3" d="M0 1114.5h1179.93"/>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">MESSAGES</tspan>
 			</text>
 		</g>
@@ -1460,7 +1460,7 @@
 			<g id="File-input" transform="translate(2 430)">
 				<rect id="Mediawiki.Neutral.Hover-32-Copy-2" width="459" height="31" x=".5" y=".5" fill="#FFF" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
 				<path id="Rectangle-640-Copy-20" fill="#F8F9FA" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" d="M345.5 31.5V.5h112.504c.827 0 1.496.672 1.496 1.502v27.996c0 .834-.667 1.502-1.496 1.502H345.5z"/>
-				<text id="Select-a-file" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Select-a-file" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="358.568" y="23">Select a file</tspan>
 				</text>
 			</g>
@@ -1471,16 +1471,16 @@
 				<path id="Mediawiki.Neutral.Hover-copy-28" d="M16-.5h28c9.113 0 16.5 7.387 16.5 16.5 0 9.114-7.387 16.5-16.5 16.5H16C6.887 32.5-.5 25.113-.5 16-.5 6.886 6.887-.5 16-.5z"/>
 				<circle id="Oval-45-Copy-13" cx="17" cy="16" r="10.5"/>
 			</g>
-			<text id="Option-4-Copy-5" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Option-4-Copy-5" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="2" y="697">Option 1</tspan>
 			</text>
 			<g id="Text-input-/-!default" transform="translate(2 374)">
 				<rect id="border" width="459" height="31" x=".5" y=".5" fill="#FFF" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
 			</g>
-			<text id="Re-enter-password-2-Copy-3" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Re-enter-password-2-Copy-3" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="16" y="396">Re-enter password</tspan>
 			</text>
-			<text id="Password-on-general" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Password-on-general" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1" y="365">Password on general purpose</tspan>
 			</text>
 			<g id="_Spec-101-/-4-sp-(0.25-em)" stroke="#F5A623" stroke-width="4" transform="translate(478 370)">
@@ -1490,10 +1490,10 @@
 				<path fill="#FFF" stroke-width="2" d="M4 298c-.555 0-1 .444-1 1.002v27.996A.998.998 0 004 328h456c.555 0 1-.444 1-1.002v-27.996a.998.998 0 00-1-1.002H4z"/>
 				<path d="M4 297.5c-.83 0-1.5.668-1.5 1.502v27.996c0 .831.67 1.502 1.5 1.502h456c.83 0 1.5-.668 1.5-1.502v-27.996c0-.831-.67-1.502-1.5-1.502H4z"/>
 			</g>
-			<text id="Volker" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Volker" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="16" y="319">Volker</tspan>
 			</text>
-			<text id="Username" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Username" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1" y="288">Username</tspan>
 			</text>
 			<path id="Line" stroke="#000" stroke-linecap="square" d="M61.799 303.5v19"/>
@@ -1505,16 +1505,16 @@
 				</g>
 			</g>
 			<g id="Checkbox-/-!default" transform="translate(2 575)">
-				<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="33" y="22">CheckboxMultiSelect label</tspan>
 				</text>
 				<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>
 			</g>
-			<text id="Option-with-a-really" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Option-with-a-really" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="2" y="747">Option with a really long label</tspan>
 			</text>
 			<g id="Radio-/-:checked-/-!default" transform="translate(2 522)">
-				<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="33" y="22">Radio button with really long label</tspan>
 				</text>
 				<g id="Oval-112-Copy-3-+-Oval-59-Copy-2" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -1523,13 +1523,13 @@
 				</g>
 			</g>
 			<g id="Radio-/-!default" transform="translate(2 480)">
-				<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="33" y="22">Neutral point</tspan>
 				</text>
 				<path id="Oval-112-Copy-2" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" d="M12 27.5c6.351 0 11.5-5.149 11.5-11.5S18.351 4.5 12 4.5.5 9.649.5 16 5.649 27.5 12 27.5z"/>
 			</g>
 			<g id="Checkbox-/-:checked-/-!default" transform="translate(2 616)">
-				<text id="Neutral-point" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="Neutral-point" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="33" y="23">Neutral point</tspan>
 				</text>
 				<g id="Checkbox" fill-rule="evenodd" stroke-width="1" transform="translate(0 5)">
@@ -1541,12 +1541,12 @@
 			</g>
 			<g id="Button-/---progressive-/-!default" transform="translate(2 786)">
 				<rect id="bg" width="122" height="31" x=".5" y=".5" fill="#36C" fill-rule="evenodd" stroke="#36C" stroke-width="1" rx="2"/>
-				<text id="label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="32.384" y="22">Primary</tspan>
 				</text>
 			</g>
-			<text id="The-document-contain" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
-				<tspan x="1" y="128" fill="#222">The document containing a hyperlink is known as its </tspan> <tspan x="379.768" y="128" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-weight="bold">source</tspan> <tspan x="431.928" y="128" fill="#222"> </tspan> <tspan x="1" y="150.4" fill="#222">document. For example, in an online reference work such as </tspan> <tspan x="1" y="172.8" fill="#222">Wikipedia, many words and terms in the text are hyperlinked to </tspan> <tspan x="1" y="195.2" fill="#222">definitions of those terms. </tspan> <tspan x="190.968" y="195.2" fill="#36C">Hyperlinks</tspan> <tspan x="266.232" y="195.2" fill="#222"> are often used to </tspan> <tspan x="1" y="217.6" fill="#222">implement reference mechanisms, such as tables of contents, </tspan> <tspan x="1" y="240" fill="#222">footnotes, bibliographies, indexes, letters, and glossaries.</tspan>
+			<text id="The-document-contain" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
+				<tspan x="1" y="128" fill="#222">The document containing a hyperlink is known as its </tspan> <tspan x="379.768" y="128" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-weight="bold">source</tspan> <tspan x="431.928" y="128" fill="#222"> </tspan> <tspan x="1" y="150.4" fill="#222">document. For example, in an online reference work such as </tspan> <tspan x="1" y="172.8" fill="#222">Wikipedia, many words and terms in the text are hyperlinked to </tspan> <tspan x="1" y="195.2" fill="#222">definitions of those terms. </tspan> <tspan x="190.968" y="195.2" fill="#36C">Hyperlinks</tspan> <tspan x="266.232" y="195.2" fill="#222"> are often used to </tspan> <tspan x="1" y="217.6" fill="#222">implement reference mechanisms, such as tables of contents, </tspan> <tspan x="1" y="240" fill="#222">footnotes, bibliographies, indexes, letters, and glossaries.</tspan>
 			</text>
 			<g id="_Spec-101-/-32-sp-(2-em)" stroke="#13B9FE" stroke-width="4" transform="rotate(90 55 429)">
 				<path id="32-sp-(2-em)" d="M0 4h32" transform="matrix(1 0 0 -1 0 8)"/>
@@ -1554,10 +1554,10 @@
 			<g id="_Spec-101-/-16-sp-(1-em)" stroke="#D0021B" stroke-width="4" transform="rotate(90 74.5 407.5)">
 				<path id="16-sp-(1-em)" d="M0 2h16"/>
 			</g>
-			<text id="`margin-bottom:-1.25" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="`margin-bottom:-1.25" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="500" y="347">`margin-bottom: 1.25em` between widgets with labels </tspan>
 			</text>
-			<text id="`margin-bottom:-1.5e" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="`margin-bottom:-1.5e" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="500" y="420">`margin-bottom: 1.5em` between widgets without labels </tspan>
 			</text>
 			<g id="_Spec-101-/-4-sp-(0.25-em)" stroke="#F5A623" stroke-width="4" transform="translate(478 329)">
@@ -1586,7 +1586,7 @@
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 93)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">EXAMPLE </tspan> <tspan x="0" y="80">FORM</tspan>
 			</text>
 			<g id="_Spec-101-/-24-sp-(1.5-em)" stroke="#A65DE7" stroke-width="4" transform="rotate(90 38 444)">
@@ -1612,31 +1612,31 @@
 			</g>
 		</g>
 		<g id="DATE-PICKER-2ND-WAY" transform="translate(13351 1415)">
-			<text id="2-WAYS-OF-CHOOSING-D" fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text id="2-WAYS-OF-CHOOSING-D" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x=".596" y="36.24">2 WAYS OF CHOOSING DATE</tspan>
 			</text>
-			<text id="1.-Starting-the-proc" fill="#333" font-family="Lato-Bold, Lato" font-size="21" font-weight="bold">
+			<text id="1.-Starting-the-proc" fill="#333" font-family="Lato-Bold, Lato, sans-serif" font-size="21" font-weight="bold">
 				<tspan x="1.596" y="130.24">1. Starting the process from scratch. Choosing YYYY, MM, DD</tspan>
 			</text>
-			<text id="Step-1:-Choosing-yea" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="Step-1:-Choosing-yea" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="25.596" y="179.24">Step 1: Choosing year</tspan>
 			</text>
-			<text id="Step-2:-Choosing-mon" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="Step-2:-Choosing-mon" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="415.596" y="179.24">Step 2: Choosing month</tspan>
 			</text>
-			<text id="Step-3:-Choosing-day" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="Step-3:-Choosing-day" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="800.596" y="179.24">Step 3: Choosing day</tspan>
 			</text>
-			<text id="Clicking-on-year-in-" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="Clicking-on-year-in-" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="25.596" y="750.24">Clicking on year in the field to change year</tspan>
 			</text>
-			<text id="Clicking-on-month-in" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="Clicking-on-month-in" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="415.596" y="750.24">Clicking on month in the field to change month</tspan>
 			</text>
-			<text id="Clicking-on-day-in-t" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="Clicking-on-day-in-t" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="800.596" y="750.24">Clicking on day in the field to change day</tspan>
 			</text>
-			<text id="2.-Clicking-on-YYYY," fill="#333" font-family="Lato-Bold, Lato" font-size="21" font-weight="bold">
+			<text id="2.-Clicking-on-YYYY," fill="#333" font-family="Lato-Bold, Lato, sans-serif" font-size="21" font-weight="bold">
 				<tspan x="1.596" y="700.24">2. Clicking on YYYY, MM, or DD to alter a specific part of the date.</tspan>
 			</text>
 			<g id="Mediawiki.Neutral.Hover-38-Copy-8">
@@ -1648,33 +1648,33 @@
 			<rect id="Mediawiki.Neutral.Acive-copy-30" width="10" height="10" x="1066.596" y="847.94" fill="#000" rx="2"/>
 			<rect id="Rectangle-605-Copy-8" width="47" height="35" x="855.096" y="952.44" fill="#36C" stroke="#36C" rx="2"/>
 			<rect id="Rectangle-608-Copy-2" width="47" height="35" x="952.096" y="988.44" stroke="#165C91" rx="2"/>
-			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="824.404" y="902.94" fill="#000">S</tspan> <tspan x="820.7" y="939.404" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">28</tspan> <tspan x="825.148" y="975.852" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">4</tspan> <tspan x="820.7" y="1012.3" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">11</tspan> <tspan x="820.7" y="1048.748" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">18</tspan> <tspan x="820.7" y="1085.196" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">25</tspan>
+			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="824.404" y="902.94" fill="#000">S</tspan> <tspan x="820.7" y="939.404" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">28</tspan> <tspan x="825.148" y="975.852" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">4</tspan> <tspan x="820.7" y="1012.3" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">11</tspan> <tspan x="820.7" y="1048.748" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">18</tspan> <tspan x="820.7" y="1085.196" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">25</tspan>
 			</text>
-			<text id="M" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="871.34" y="902.94" fill="#000">M</tspan> <tspan x="869.7" y="939.404" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">29</tspan> <tspan x="874.148" y="975.852" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">5</tspan> <tspan x="869.7" y="1012.3" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">12</tspan> <tspan x="869.7" y="1048.748" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">19</tspan> <tspan x="869.7" y="1085.196" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">26</tspan>
+			<text id="M" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="871.34" y="902.94" fill="#000">M</tspan> <tspan x="869.7" y="939.404" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">29</tspan> <tspan x="874.148" y="975.852" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">5</tspan> <tspan x="869.7" y="1012.3" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">12</tspan> <tspan x="869.7" y="1048.748" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">19</tspan> <tspan x="869.7" y="1085.196" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">26</tspan>
 			</text>
-			<text id="T" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="922.708" y="902.94" fill="#000">T</tspan> <tspan x="918.7" y="939.404" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">30</tspan> <tspan x="923.148" y="975.852" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">6</tspan> <tspan x="918.7" y="1012.3" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">13</tspan> <tspan x="918.7" y="1048.748" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">20</tspan> <tspan x="918.7" y="1085.196" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">27</tspan>
+			<text id="T" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="922.708" y="902.94" fill="#000">T</tspan> <tspan x="918.7" y="939.404" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">30</tspan> <tspan x="923.148" y="975.852" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">6</tspan> <tspan x="918.7" y="1012.3" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">13</tspan> <tspan x="918.7" y="1048.748" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">20</tspan> <tspan x="918.7" y="1085.196" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">27</tspan>
 			</text>
-			<text id="W" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="968.044" y="902.94" fill="#000">W</tspan> <tspan x="966.7" y="939.404" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">31</tspan> <tspan x="971.148" y="975.852" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">7</tspan> <tspan x="966.7" y="1012.3" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">14</tspan> <tspan x="966.7" y="1048.748" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">21</tspan> <tspan x="966.7" y="1085.196" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">28</tspan>
+			<text id="W" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="968.044" y="902.94" fill="#000">W</tspan> <tspan x="966.7" y="939.404" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">31</tspan> <tspan x="971.148" y="975.852" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">7</tspan> <tspan x="966.7" y="1012.3" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">14</tspan> <tspan x="966.7" y="1048.748" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">21</tspan> <tspan x="966.7" y="1085.196" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">28</tspan>
 			</text>
-			<text id="T-Copy-4" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="1018.708" y="902.94">T</tspan> <tspan x="1019.148" y="939.404" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">1</tspan> <tspan x="1019.148" y="975.852" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">8</tspan> <tspan x="1014.7" y="1012.3" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">15</tspan> <tspan x="1014.7" y="1048.748" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">22</tspan> <tspan x="1014.7" y="1085.196" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">29</tspan>
+			<text id="T-Copy-4" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="1018.708" y="902.94">T</tspan> <tspan x="1019.148" y="939.404" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">1</tspan> <tspan x="1019.148" y="975.852" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">8</tspan> <tspan x="1014.7" y="1012.3" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">15</tspan> <tspan x="1014.7" y="1048.748" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">22</tspan> <tspan x="1014.7" y="1085.196" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">29</tspan>
 			</text>
-			<text id="F-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="1066.852" y="902.94">F</tspan> <tspan x="1067.148" y="939.404" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">2</tspan> <tspan x="1067.148" y="975.852" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">9</tspan> <tspan x="1062.7" y="1012.3" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">16</tspan> <tspan x="1062.7" y="1048.748" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">23</tspan> <tspan x="1062.7" y="1085.196" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">30</tspan>
+			<text id="F-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="1066.852" y="902.94">F</tspan> <tspan x="1067.148" y="939.404" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">2</tspan> <tspan x="1067.148" y="975.852" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">9</tspan> <tspan x="1062.7" y="1012.3" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">16</tspan> <tspan x="1062.7" y="1048.748" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">23</tspan> <tspan x="1062.7" y="1085.196" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">30</tspan>
 			</text>
-			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="1114.404" y="902.94" fill="#000">S</tspan> <tspan x="1115.148" y="939.404" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">3</tspan> <tspan x="1110.7" y="975.852" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">10</tspan> <tspan x="1110.7" y="1012.3" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">17</tspan> <tspan x="1110.7" y="1048.748" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">24</tspan> <tspan x="1115.148" y="1085.196" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">1</tspan>
+			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="1114.404" y="902.94" fill="#000">S</tspan> <tspan x="1115.148" y="939.404" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">3</tspan> <tspan x="1110.7" y="975.852" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">10</tspan> <tspan x="1110.7" y="1012.3" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">17</tspan> <tspan x="1110.7" y="1048.748" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">24</tspan> <tspan x="1115.148" y="1085.196" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">1</tspan>
 			</text>
 			<path id="Imported-Layers-60-Copy-6" fill="#000" d="M828.463 849.886a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.505c-.564-.52-1.47-.501-2.033.019l-.577.534 7.5 6.956 7.5-6.956-.578-.543z"/>
 			<path id="Imported-Layers-61-Copy-14" fill="#000" d="M1127.018 850.33a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.019l-.578.534 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(1 0 0 -1 0 1707.88)"/>
 			<path id="Rectangle-607-Copy-12" fill="#EAF3FF" d="M849 788h22v32h-22z"/>
 			<path id="Imported-Layers-61-Copy-15" fill="#000" d="M1029.018 850.33a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.019l-.578.534 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(-1 0 0 1 2044.192 0)"/>
 			<path id="Line-Copy-44" fill="#FFF" stroke="#72777D" d="M802.596 820.94h347.03"/>
-			<text id="Tue-14-Nov-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-14-Nov-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="821" y="810">Tue 14 Nov 2013</tspan>
 			</text>
 			<g id="Mediawiki.Neutral.Hover-38-Copy-5">
@@ -1691,37 +1691,37 @@
 			<rect id="Mediawiki.Neutral.Acive-copy-31" width="20" height="20" x="725" y="793" fill="#222" rx="2"/>
 			<rect id="Rectangle-605-Copy-6" width="166" height="35" x="593.096" y="445.74" fill="#36C" stroke="#36C" rx="2"/>
 			<rect id="Rectangle-605-Copy-9" width="166" height="35" x="593.096" y="1023.44" fill="#36C" stroke="#36C" rx="2"/>
-			<text id="January---01-Copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="January---01-Copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="434.596" y="323.24">January 01</tspan> <tspan x="434.596" y="359.688">February 02</tspan> <tspan x="434.596" y="396.136">March 03</tspan> <tspan x="434.596" y="432.584">April 04</tspan> <tspan x="434.596" y="469.032">May 05</tspan> <tspan x="434.596" y="505.48">June 06</tspan>
 			</text>
-			<text id="January---01-Copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="January---01-Copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="434.596" y="901.94">January 01</tspan> <tspan x="434.596" y="938.388">February 02</tspan> <tspan x="434.596" y="974.836">March 03</tspan> <tspan x="434.596" y="1011.284">April 04</tspan> <tspan x="434.596" y="1047.732">May 05</tspan> <tspan x="434.596" y="1084.18">June 06</tspan>
 			</text>
-			<text id="July---07" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="July---07" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="613.596" y="323.24" fill="#000">July 07</tspan> <tspan x="613.596" y="359.688" fill="#000">August 08</tspan> <tspan x="613.596" y="396.136" fill="#000">September 09</tspan> <tspan x="613.596" y="432.584" fill="#000">October 10</tspan> <tspan x="613.596" y="469.032" fill="#FFF">November 11</tspan> <tspan x="613.596" y="505.48" fill="#000">December 12</tspan>
 			</text>
-			<text id="July---07" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="July---07" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="613.596" y="901.94" fill="#000">July 07</tspan> <tspan x="613.596" y="938.388" fill="#000">August 08</tspan> <tspan x="613.596" y="974.836" fill="#000">September 09</tspan> <tspan x="613.596" y="1011.284" fill="#000">October 10</tspan> <tspan x="613.596" y="1047.732" fill="#FFF">November 11</tspan> <tspan x="613.596" y="1084.18" fill="#000">December 12</tspan>
 			</text>
 			<path id="Line-Copy-43" fill="#FFF" stroke="#72777D" d="M416.596 245.24h348.03"/>
 			<path id="Line-Copy-46" fill="#FFF" stroke="#72777D" d="M417.596 820.94h347.03"/>
 			<path id="Rectangle-607-Copy-11" fill="#EAF3FF" d="M485 788h33v32h-33z"/>
-			<text id="YYYY-MM-DD" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="YYYY-MM-DD" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="434.596" y="233.24">YYYY-MM-DD</tspan>
 			</text>
 			<path id="Line" stroke="#000" stroke-linecap="square" d="M537.799 218.5v19"/>
-			<text id="Tue-14-Nov-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-14-Nov-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="435" y="810">Tue 14 Nov 2013</tspan>
 			</text>
-			<text id="November-2013-Copy-3" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="November-2013-Copy-3" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="837.596" y="860.94">November 2013</tspan>
 			</text>
 			<path id="Imported-Layers-60-Copy-5" fill="#000" d="M443.018 271.63a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.019l-.578.534 7.5 6.956 7.5-6.956-.578-.544z" transform="rotate(90 436.096 275.24)"/>
 			<path id="Imported-Layers-60-Copy-7" fill="#000" d="M443.018 850.33a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.019l-.578.534 7.5 6.956 7.5-6.956-.578-.544z" transform="rotate(90 436.096 853.94)"/>
-			<text id="Type-something-Copy-4" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Type-something-Copy-4" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="451.804" y="282.24">2013</tspan>
 			</text>
-			<text id="Type-something-Copy-5" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Type-something-Copy-5" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="451.804" y="860.94">2013</tspan>
 			</text>
 			<g id="Group-2" filter="url(#filter-12)" transform="translate(801 207)">
@@ -1733,36 +1733,36 @@
 				<rect id="Mediawiki.Neutral.Acive-copy-26" width="10" height="10" x="265.596" y="62.24" fill="#000" rx="2"/>
 				<rect id="Rectangle-605-Copy-3" width="47" height="35" x="54.096" y="166.74" fill="#36C" stroke="#36C" rx="2"/>
 				<rect id="Rectangle-608-Copy" width="47" height="35" x="151.096" y="202.74" stroke="#165C91" rx="2"/>
-				<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="23.404" y="117.24" fill="#000">S</tspan> <tspan x="19.7" y="153.704" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">28</tspan> <tspan x="24.148" y="190.152" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">4</tspan> <tspan x="19.7" y="226.6" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">11</tspan> <tspan x="19.7" y="263.048" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">18</tspan> <tspan x="19.7" y="299.496" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">25</tspan>
+				<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="23.404" y="117.24" fill="#000">S</tspan> <tspan x="19.7" y="153.704" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">28</tspan> <tspan x="24.148" y="190.152" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">4</tspan> <tspan x="19.7" y="226.6" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">11</tspan> <tspan x="19.7" y="263.048" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">18</tspan> <tspan x="19.7" y="299.496" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">25</tspan>
 				</text>
-				<text id="M" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="70.34" y="117.24" fill="#000">M</tspan> <tspan x="68.7" y="153.704" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">29</tspan> <tspan x="73.148" y="190.152" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">5</tspan> <tspan x="68.7" y="226.6" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">12</tspan> <tspan x="68.7" y="263.048" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">19</tspan> <tspan x="68.7" y="299.496" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">26</tspan>
+				<text id="M" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="70.34" y="117.24" fill="#000">M</tspan> <tspan x="68.7" y="153.704" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">29</tspan> <tspan x="73.148" y="190.152" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">5</tspan> <tspan x="68.7" y="226.6" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">12</tspan> <tspan x="68.7" y="263.048" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">19</tspan> <tspan x="68.7" y="299.496" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">26</tspan>
 				</text>
-				<text id="T" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="121.708" y="117.24" fill="#000">T</tspan> <tspan x="117.7" y="153.704" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">30</tspan> <tspan x="122.148" y="190.152" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">6</tspan> <tspan x="117.7" y="226.6" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">13</tspan> <tspan x="117.7" y="263.048" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">20</tspan> <tspan x="117.7" y="299.496" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">27</tspan>
+				<text id="T" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="121.708" y="117.24" fill="#000">T</tspan> <tspan x="117.7" y="153.704" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">30</tspan> <tspan x="122.148" y="190.152" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">6</tspan> <tspan x="117.7" y="226.6" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">13</tspan> <tspan x="117.7" y="263.048" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">20</tspan> <tspan x="117.7" y="299.496" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">27</tspan>
 				</text>
-				<text id="W" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="167.044" y="117.24" fill="#000">W</tspan> <tspan x="165.7" y="153.704" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">31</tspan> <tspan x="170.148" y="190.152" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">7</tspan> <tspan x="165.7" y="226.6" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">14</tspan> <tspan x="165.7" y="263.048" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">21</tspan> <tspan x="165.7" y="299.496" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">28</tspan>
+				<text id="W" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="167.044" y="117.24" fill="#000">W</tspan> <tspan x="165.7" y="153.704" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">31</tspan> <tspan x="170.148" y="190.152" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">7</tspan> <tspan x="165.7" y="226.6" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">14</tspan> <tspan x="165.7" y="263.048" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">21</tspan> <tspan x="165.7" y="299.496" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">28</tspan>
 				</text>
-				<text id="T-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="217.708" y="117.24">T</tspan> <tspan x="218.148" y="153.704" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">1</tspan> <tspan x="218.148" y="190.152" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">8</tspan> <tspan x="213.7" y="226.6" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">15</tspan> <tspan x="213.7" y="263.048" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">22</tspan> <tspan x="213.7" y="299.496" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">29</tspan>
+				<text id="T-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="217.708" y="117.24">T</tspan> <tspan x="218.148" y="153.704" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">1</tspan> <tspan x="218.148" y="190.152" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">8</tspan> <tspan x="213.7" y="226.6" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">15</tspan> <tspan x="213.7" y="263.048" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">22</tspan> <tspan x="213.7" y="299.496" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">29</tspan>
 				</text>
-				<text id="F-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="265.852" y="117.24">F</tspan> <tspan x="266.148" y="153.704" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">2</tspan> <tspan x="266.148" y="190.152" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">9</tspan> <tspan x="261.7" y="226.6" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">16</tspan> <tspan x="261.7" y="263.048" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">23</tspan> <tspan x="261.7" y="299.496" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">30</tspan>
+				<text id="F-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="265.852" y="117.24">F</tspan> <tspan x="266.148" y="153.704" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">2</tspan> <tspan x="266.148" y="190.152" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">9</tspan> <tspan x="261.7" y="226.6" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">16</tspan> <tspan x="261.7" y="263.048" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">23</tspan> <tspan x="261.7" y="299.496" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">30</tspan>
 				</text>
-				<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-					<tspan x="313.404" y="117.24" fill="#000">S</tspan> <tspan x="314.148" y="153.704" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">3</tspan> <tspan x="309.7" y="190.152" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">10</tspan> <tspan x="309.7" y="226.6" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">17</tspan> <tspan x="309.7" y="263.048" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">24</tspan> <tspan x="314.148" y="299.496" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">1</tspan>
+				<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+					<tspan x="313.404" y="117.24" fill="#000">S</tspan> <tspan x="314.148" y="153.704" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">3</tspan> <tspan x="309.7" y="190.152" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">10</tspan> <tspan x="309.7" y="226.6" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">17</tspan> <tspan x="309.7" y="263.048" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">24</tspan> <tspan x="314.148" y="299.496" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">1</tspan>
 				</text>
 				<path id="Imported-Layers-60-Copy-4" fill="#000" d="M27.463 64.186a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.505c-.564-.52-1.47-.501-2.033.019l-.577.534 7.5 6.956 7.5-6.956-.578-.543z"/>
 				<path id="Imported-Layers-61-Copy-9" fill="#000" d="M326.018 64.63a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.019l-.578.534 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(1 0 0 -1 0 136.48)"/>
 				<path id="Imported-Layers-61-Copy-10" fill="#000" d="M228.018 64.63a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.019l-.578.534 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(-1 0 0 1 442.192 0)"/>
 				<path id="Line-Copy-42" fill="#FFF" stroke="#72777D" d="M1.596 38.24h348.03"/>
-				<text id="YYYY-MM-DD" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="YYYY-MM-DD" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="19.596" y="26.24">YYYY-MM-DD</tspan>
 				</text>
 				<path id="Line" stroke="#000" stroke-linecap="square" d="M122.799 11.5v19"/>
-				<text id="November-2013-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="November-2013-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="36.596" y="75.24">November 2013</tspan>
 				</text>
 				<ellipse id="Oval-221-Copy-4" cx="270.096" cy="67.24" stroke="#555" stroke-width="2" rx="12.5" ry="10" transform="rotate(-14 270.096 67.24)"/>
@@ -1788,46 +1788,46 @@
 				<rect width="349" height="322.3" x="26.096" y="785.14" stroke="#36C" rx="2"/>
 			</g>
 			<rect id="Mediawiki.Neutral.Acive-copy-32" width="20" height="20" x="335" y="793" fill="#222" rx="2"/>
-			<text id="1986-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="1986-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="41.596" y="321.94">1986</tspan> <tspan x="41.596" y="358.388">1987</tspan> <tspan x="41.596" y="394.836">1988</tspan> <tspan x="41.596" y="431.284">1989</tspan> <tspan x="41.596" y="467.732">1990</tspan> <tspan x="41.596" y="504.18">1991</tspan>
 			</text>
-			<text id="1986-copy-3" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="1986-copy-3" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="41.596" y="900.64">1986</tspan> <tspan x="41.596" y="937.088">1987</tspan> <tspan x="41.596" y="973.536">1988</tspan> <tspan x="41.596" y="1009.984">1989</tspan> <tspan x="41.596" y="1046.432">1990</tspan> <tspan x="41.596" y="1082.88">1991</tspan>
 			</text>
-			<text id="1992-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="1992-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="112.596" y="321.94">1992</tspan> <tspan x="112.596" y="358.388">1993</tspan> <tspan x="112.596" y="394.836">1994</tspan> <tspan x="112.596" y="431.284">1995</tspan> <tspan x="112.596" y="467.732">1996</tspan> <tspan x="112.596" y="504.18">1997</tspan>
 			</text>
-			<text id="1992-copy-3" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="1992-copy-3" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="112.596" y="900.64">1992</tspan> <tspan x="112.596" y="937.088">1993</tspan> <tspan x="112.596" y="973.536">1994</tspan> <tspan x="112.596" y="1009.984">1995</tspan> <tspan x="112.596" y="1046.432">1996</tspan> <tspan x="112.596" y="1082.88">1997</tspan>
 			</text>
 			<rect id="Rectangle-608-Copy-6" width="59" height="35" x="308.096" y="408.44" fill="#36C" stroke="#36C" rx="2"/>
 			<rect id="Rectangle-608-Copy-7" width="59" height="35" x="308.096" y="985.14" fill="#36C" stroke="#36C" rx="2"/>
-			<text id="19981999-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="19981999-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="182.596" y="321.94">1998</tspan> <tspan x="182.596" y="358.388">1999</tspan> <tspan x="182.596" y="394.836">2000</tspan> <tspan x="182.596" y="431.284">2001</tspan> <tspan x="182.596" y="467.732">2002</tspan> <tspan x="182.596" y="504.18">2003</tspan>
 			</text>
-			<text id="19981999-copy-3" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="19981999-copy-3" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="182.596" y="900.64">1998</tspan> <tspan x="182.596" y="937.088">1999</tspan> <tspan x="182.596" y="973.536">2000</tspan> <tspan x="182.596" y="1009.984">2001</tspan> <tspan x="182.596" y="1046.432">2002</tspan> <tspan x="182.596" y="1082.88">2003</tspan>
 			</text>
-			<text id="2004-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="2004-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="251.596" y="321.94">2004</tspan> <tspan x="251.596" y="358.388">2005</tspan> <tspan x="251.596" y="394.836">2006</tspan> <tspan x="251.596" y="431.284">2007</tspan> <tspan x="251.596" y="467.732">2008</tspan> <tspan x="251.596" y="504.18">2009</tspan>
 			</text>
-			<text id="2004-copy-3" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="2004-copy-3" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="251.596" y="900.64">2004</tspan> <tspan x="251.596" y="937.088">2005</tspan> <tspan x="251.596" y="973.536">2006</tspan> <tspan x="251.596" y="1009.984">2007</tspan> <tspan x="251.596" y="1046.432">2008</tspan> <tspan x="251.596" y="1082.88">2009</tspan>
 			</text>
-			<text id="2010" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="2010" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="319.596" y="321.94" fill="#000">2010</tspan> <tspan x="319.596" y="358.388" fill="#000">2011</tspan> <tspan x="319.596" y="394.836" fill="#000">2012</tspan> <tspan x="319.596" y="431.284" fill="#FFF">2013</tspan> <tspan x="319.596" y="467.732" fill="#000">2014</tspan> <tspan x="319.596" y="504.18" fill="#000">2015</tspan>
 			</text>
-			<text id="2010" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="2010" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="319.596" y="900.64" fill="#000">2010</tspan> <tspan x="319.596" y="937.088" fill="#000">2011</tspan> <tspan x="319.596" y="973.536" fill="#000">2012</tspan> <tspan x="319.596" y="1009.984" fill="#FFF">2013</tspan> <tspan x="319.596" y="1046.432" fill="#000">2014</tspan> <tspan x="319.596" y="1082.88" fill="#000">2015</tspan>
 			</text>
 			<path id="Line-Copy-45" fill="#FFF" stroke="#72777D" d="M27.596 244.94h346.03"/>
 			<path id="Line-Copy-47" fill="#FFF" stroke="#72777D" d="M27 819.5h347"/>
 			<path id="Rectangle-607-Copy-13" fill="#EAF3FF" d="M127.596 786.64h41v32h-41z"/>
-			<text id="YYYY-MM-DD" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="YYYY-MM-DD" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="44.596" y="232.94">YYYY-MM-DD</tspan>
 			</text>
 			<path id="Line" stroke="#000" stroke-linecap="square" d="M147.799 218.5v19"/>
-			<text id="Tue-14-Nov-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-14-Nov-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="45" y="810">Tue 14 Nov 2013</tspan>
 			</text>
 			<path id="Imported-Layers-61-Copy-12" fill="#000" d="M345.018 271.33a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.019l-.578.534 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(1 0 0 -1 0 549.88)"/>
@@ -1845,10 +1845,10 @@
 			<path id="Line-Copy-50" fill="#C70070" fill-rule="nonzero" d="M860.096 767.624l-.001 15.884h4l-4.5 9-4.5-9h4v-15.884h1z"/>
 		</g>
 		<g id="DATE-PICKER" transform="translate(11520 142)">
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">DATE </tspan> <tspan x="0" y="80">PICKER</tspan>
 			</text>
-			<text id="Normal-Disabled-Text" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Normal-Disabled-Text" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="1.251" y="134.24">Normal </tspan> <tspan x="1.251" y="190.34">Disabled</tspan> <tspan x="1.251" y="452.14">Text field </tspan> <tspan x="1.251" y="470.84">Interaction</tspan> <tspan x="1.251" y="900.94">Calendar </tspan> <tspan x="1.251" y="919.64">Expanded</tspan> <tspan x="1.251" y="1312.34"> </tspan> <tspan x="1.251" y="1518.04">Calendar</tspan> <tspan x="1.251" y="1536.74">interaction</tspan>
 			</text>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(2.25 96.24)">
@@ -1859,14 +1859,14 @@
 				<rect width="200" height="30" x="1015.251" y="886.968" fill="#FFF" stroke-width="2" rx="2"/>
 				<rect width="201" height="31" x="1014.751" y="886.468" rx="2"/>
 			</g>
-			<text id="Tue-Nov-5,-2020" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2020" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="215.749" y="135.76">Tue Nov 5, 2013</tspan>
 			</text>
-			<text id="Tue-Nov-5,-2016" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2016" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1028" y="908">Tue Nov 5, 2013</tspan>
 			</text>
 			<rect id="Mediawiki.Neutral.Hover-36" width="201" height="31" x="202.751" y="170.5" fill="#C8CCD1" stroke="#C8CCD1" rx="2"/>
-			<text id="Tue-Nov-5,-2019" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Tue-Nov-5,-2019" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="218" y="192">Tue Nov 5, 2013</tspan>
 			</text>
 			<rect id="Mediawiki.Neutral.Acive-copy-9" width="20" height="20" x="369" y="177" fill="#949494" rx="2"/>
@@ -1875,26 +1875,26 @@
 			<path id="Line-214" stroke="#D0021B" stroke-width="4" d="M385.251 905.24h16"/>
 			<rect id="Mediawiki.Neutral.Hover-36" width="201" height="31" x="200.5" y="886.5" fill="#FFF" stroke="#72777D" rx="2"/>
 			<path id="Rectangle-600" fill="#F8F9FA" d="M353 887h45.999a2 2 0 012.001 1.992v26.016c0 1.1-.895 1.992-2.001 1.992H353v-30z"/>
-			<text id="Tue-Nov-5,-2024" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2024" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="218" y="908">Tue Nov 5, 2013</tspan>
 			</text>
 			<rect id="Mediawiki.Neutral.Acive-copy-14" width="20" height="20" x="366.251" y="892.24" fill="#222" rx="2"/>
-			<text id="Tue-Nov-5,-2024-Copy" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2024-Copy" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="441" y="908">Tue Nov 5, 2013</tspan>
 			</text>
 			<g id="_Spec-101-/-16-sp-(1-em)" stroke="#D0021B" stroke-width="4" transform="translate(389 186)">
 				<path id="16-sp-(1-em)" d="M0 2h16"/>
 			</g>
 			<rect id="Rectangle-612" width="48" height="36" x="1122" y="199.552" fill="#F8F9FA" rx="2"/>
-			<text id="5" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="5" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1141.552" y="224">5</tspan>
 			</text>
 			<rect id="Rectangle-612-Copy-2" width="48" height="36" x="1122" y="252.552" fill="#36C" rx="2"/>
-			<text id="5-copy-2" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="5-copy-2" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1141.552" y="277">5</tspan>
 			</text>
 			<rect id="Rectangle-612-Copy" width="47" height="35" x="1122.5" y="303.052" fill="#2A4B8D" stroke="#2A4B8D" rx="2"/>
-			<text id="5-copy" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="5-copy" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1141.552" y="327">5</tspan>
 			</text>
 			<g id="Mediawiki.Neutral.Hover-31" stroke="#36C" stroke-linejoin="square">
@@ -1904,70 +1904,70 @@
 			<rect id="Mediawiki.Neutral.Hover-31" width="201" height="31" x="202.5" y="432.5" fill="#FFF" stroke="#72777D" rx="2"/>
 			<path id="Rectangle-606" fill="#F8F9FA" d="M297 433h36v30h-36z"/>
 			<path id="Rectangle-610" fill="#EAECF0" d="M517 434h34v28h-34z"/>
-			<text id="Tue-Nov-5,-2015" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2015" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="217" y="454">Tue Nov 5, 2013</tspan>
 			</text>
 			<rect id="Mediawiki.Neutral.Acive-copy-5" width="20" height="20" x="368" y="437.486" fill="#222" rx="2"/>
-			<text id="Tue-Nov-5,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="436" y="454">Tue Nov 5, 2013</tspan>
 			</text>
 			<rect id="Mediawiki.Neutral.Acive-copy-5" width="20" height="20" x="589.751" y="437.24" fill="#222" rx="2"/>
-			<text id="•-Clicking-on-back-b" fill="#54595D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="•-Clicking-on-back-b" fill="#54595D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="182.251" y="1969.229">• Clicking on back button takes users to the “Year” selection view.</tspan> <tspan x="182.251" y="1987.229">• Scrolling up / clicking “up” button reveal the previous month. </tspan> <tspan x="182.251" y="2005.229">• Scrolling down / clicking “down” button reveals the following month.</tspan> <tspan x="182.251" y="2023.229">• When user starts typing a number, it changes the numbers within </tspan> <tspan x="182.251" y="2041.229"> highlighted area</tspan>
 			</text>
-			<text id="•--Clicking-on-back-" fill="#54595D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="•--Clicking-on-back-" fill="#54595D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="1100.596" y="1353.749">• Clicking on back button takes users to the “Year” selection view.</tspan> <tspan x="1100.596" y="1371.749">• Scrolling up / clicking “up” button reveal the previous set of years. </tspan> <tspan x="1100.596" y="1389.749">• Scrolling down / clicking “down” button reveal the following set of years.</tspan> <tspan x="1100.596" y="1407.749">• When user starts typing a number, it changes the numbers within </tspan> <tspan x="1100.596" y="1425.749"> highlighted area</tspan>
 			</text>
-			<text id="Once-user-selects-a-" fill="#54595D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Once-user-selects-a-" fill="#54595D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="194.596" y="2553.749">Once user selects a new month / day / year, the area highlighted</tspan> <tspan x="194.596" y="2571.749">will grow in size and back in place as if making one pulse. The</tspan> <tspan x="194.596" y="2589.749">highlight with more contrast and flash </tspan>
 			</text>
-			<text id="When-we-decide-to-ha" fill="#54595D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="When-we-decide-to-ha" fill="#54595D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="651.596" y="2553.749">When we decide to have users start from scratch</tspan> <tspan x="651.596" y="2571.749">in selecting a day in a year, start from the “Year”</tspan> <tspan x="651.596" y="2589.749">selection view, followed by “Month” and then “Day.”</tspan>
 			</text>
-			<text id="48-sp-(3-em)-height" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="48-sp-(3-em)-height" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="1186" y="221.552">48 sp (3 em) height</tspan>
 			</text>
-			<text id="“Currently-selected”" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="“Currently-selected”" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="1186" y="323.552">“Currently selected” style</tspan>
 			</text>
 			<g id="Rectangle-612-Copy" stroke="#36C" stroke-linejoin="square">
 				<rect width="46" height="34" x="1123" y="351.552" stroke-width="2" rx="2"/>
 				<rect width="47" height="35" x="1122.5" y="351.052" rx="2"/>
 			</g>
-			<text id="5-copy" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="5-copy" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1141.552" y="375">5</tspan>
 			</text>
-			<text id="Current-day" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="Current-day" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="1186" y="371.552">Current day</tspan>
 			</text>
-			<text id="Hover-state-style" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="Hover-state-style" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="1186" y="273.552">Hover state style</tspan>
 			</text>
-			<text id="Placeholder-icon-for" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="Placeholder-icon-for" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="1187" y="177.552">Placeholder icon for navigate to today’s day</tspan>
 			</text>
-			<text id="When-menu-is-expande" fill="#54595D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="When-menu-is-expande" fill="#54595D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="194.596" y="1345.24">When menu is expanded, clicking on the month / day / </tspan> <tspan x="194.596" y="1363.24">year, takes user to the month / day / year selection view. </tspan> <tspan x="194.596" y="1399.24">The month / day / year will be highlighted. User will be </tspan> <tspan x="194.596" y="1417.24">able to type an input like a text field or choose from the </tspan> <tspan x="194.596" y="1435.24">selection below.</tspan>
 			</text>
-			<text id="CHANGING-“MONTH”" fill="#333" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="21" font-weight="bold">
+			<text id="CHANGING-“MONTH”" fill="#333" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="21" font-weight="bold">
 				<tspan x="194.596" y="1309.24">CHANGING “MONTH”</tspan>
 			</text>
-			<text id="GOING-BACK-TO-CHANGE" fill="#333" font-family="Lato-Bold, Lato" font-size="21" font-weight="bold">
+			<text id="GOING-BACK-TO-CHANGE" fill="#333" font-family="Lato-Bold, Lato, sans-serif" font-size="21" font-weight="bold">
 				<tspan x="194.596" y="1919.24">GOING BACK TO CHANGE “MONTH”</tspan>
 			</text>
-			<text id="AFTER-A-SELECTION" fill="#333" font-family="Lato-Bold, Lato" font-size="21" font-weight="bold">
+			<text id="AFTER-A-SELECTION" fill="#333" font-family="Lato-Bold, Lato, sans-serif" font-size="21" font-weight="bold">
 				<tspan x="194.596" y="2509.24">AFTER A SELECTION</tspan>
 			</text>
-			<text id="STARTING-FROM-SCRATC" fill="#333" font-family="Lato-Bold, Lato" font-size="21" font-weight="bold">
+			<text id="STARTING-FROM-SCRATC" fill="#333" font-family="Lato-Bold, Lato, sans-serif" font-size="21" font-weight="bold">
 				<tspan x="653.596" y="2509.24">STARTING FROM SCRATCH</tspan>
 			</text>
-			<text id="GOING-BACK-TO-CHANGE" fill="#333" font-family="Lato-Bold, Lato" font-size="21" font-weight="bold">
+			<text id="GOING-BACK-TO-CHANGE" fill="#333" font-family="Lato-Bold, Lato, sans-serif" font-size="21" font-weight="bold">
 				<tspan x="654.296" y="1919.24">GOING BACK TO CHANGE “YEAR”</tspan>
 			</text>
-			<text id="CHANGING-“DAY”" fill="#333" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="21" font-weight="bold">
+			<text id="CHANGING-“DAY”" fill="#333" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="21" font-weight="bold">
 				<tspan x="652.596" y="1309.24">CHANGING “DAY”</tspan>
 			</text>
-			<text id="CHANGING-“YEAR”" fill="#333" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="21" font-weight="bold">
+			<text id="CHANGING-“YEAR”" fill="#333" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="21" font-weight="bold">
 				<tspan x="1113.596" y="1309.24">CHANGING “YEAR”</tspan>
 			</text>
 			<path id="Line-Copy-19" fill="#C70070" fill-rule="nonzero" d="M263.764 1441.24l-.001 15.884h4l-4.5 9-4.5-9h4v-15.884h1z"/>
@@ -1981,20 +1981,20 @@
 			</g>
 			<rect id="Mediawiki.Neutral.Acive-copy-21" width="20" height="20" x="963" y="2076" fill="#222" rx="2"/>
 			<rect id="Rectangle-605-Copy-2" width="157" height="35" x="839.751" y="2308.96" fill="#36C" stroke="#36C" rx="2"/>
-			<text id="January---01" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="January---01" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="675.251" y="2185.679">January 01</tspan> <tspan x="675.251" y="2222.127">February 02</tspan> <tspan x="675.251" y="2258.575">March 03</tspan> <tspan x="675.251" y="2295.023">April 04</tspan> <tspan x="675.251" y="2331.471">May 05</tspan> <tspan x="675.251" y="2367.919">June 06</tspan>
 			</text>
-			<text id="July---07" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="July---07" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="853.906" y="2185.679" fill="#000">July 07</tspan> <tspan x="853.906" y="2222.127" fill="#000">August 08</tspan> <tspan x="853.906" y="2258.575" fill="#000">September 09</tspan> <tspan x="853.906" y="2295.023" fill="#000">October 10</tspan> <tspan x="853.906" y="2331.471" fill="#FFF">November 11</tspan> <tspan x="853.906" y="2367.919" fill="#000">December 12</tspan>
 			</text>
 			<path id="Line-Copy-20" fill="#FFF" stroke="#72777D" d="M654.064 2101.96h348.03"/>
 			<path id="Rectangle-611-Copy" fill="#F8F9FA" d="M659.906 2118.94h75v36h-75z"/>
 			<path id="Rectangle-607-Copy-5" fill="#EAF3FF" d="M701 2070h32v31h-32z"/>
-			<text id="Tue-Nov-5,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="672.596" y="2092.46">Tue Nov 5, 2013</tspan>
 			</text>
 			<path id="Imported-Layers-60-Copy-3" fill="#000" d="M681.228 2133.405a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.018l-.578.534 7.5 6.957 7.5-6.957-.578-.543z"/>
-			<text id="Type-something-Copy-3" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Type-something-Copy-3" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="689.804" y="2142.24">2013</tspan>
 			</text>
 			<g id="Mediawiki.Neutral.Acive-copy-17-+-Oval-221-Copy-Copy-Copy-Copy-Copy" transform="translate(958.596 2125.24)">
@@ -2002,20 +2002,20 @@
 				<ellipse id="Oval-221-Copy" cx="15" cy="13.22" stroke="#000" stroke-width="2" rx="12.5" ry="10" transform="rotate(-14 15 13.22)"/>
 			</g>
 			<rect id="Mediawiki.Neutral.Acive-copy-20" width="20" height="20" x="505.596" y="2637.46" fill="#222" rx="2"/>
-			<text id="1986-copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="1986-copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="212.251" y="2744.679">1986</tspan> <tspan x="212.251" y="2781.127">1987</tspan> <tspan x="212.251" y="2817.575">1988</tspan> <tspan x="212.251" y="2854.023">1989</tspan> <tspan x="212.251" y="2890.471">1990</tspan> <tspan x="212.251" y="2926.919">1991</tspan>
 			</text>
-			<text id="1992-copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="1992-copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="283.251" y="2744.679">1992</tspan> <tspan x="283.251" y="2781.127">1993</tspan> <tspan x="283.251" y="2817.575">1994</tspan> <tspan x="283.251" y="2854.023">1995</tspan> <tspan x="283.251" y="2890.471">1996</tspan> <tspan x="283.251" y="2926.919">1997</tspan>
 			</text>
 			<rect id="Rectangle-608-Copy-5" width="59" height="35" x="478.751" y="2902.96" fill="#36C" stroke="#36C" rx="17.5"/>
-			<text id="19981999-copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="19981999-copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="353.251" y="2744.679">1998</tspan> <tspan x="353.251" y="2781.127">1999</tspan> <tspan x="353.251" y="2817.575">2000</tspan> <tspan x="353.251" y="2854.023">2001</tspan> <tspan x="353.251" y="2890.471">2002</tspan> <tspan x="353.251" y="2926.919">2003</tspan>
 			</text>
-			<text id="2004-copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="2004-copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="422.251" y="2744.679">2004</tspan> <tspan x="422.251" y="2781.127">2005</tspan> <tspan x="422.251" y="2817.575">2006</tspan> <tspan x="422.251" y="2854.023">2007</tspan> <tspan x="422.251" y="2890.471">2008</tspan> <tspan x="422.251" y="2926.919">2009</tspan>
 			</text>
-			<text id="2010" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="2010" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="490.251" y="2744.679" fill="#000">2010</tspan> <tspan x="490.251" y="2781.127" fill="#000">2011</tspan> <tspan x="490.251" y="2817.575" fill="#000">2012</tspan> <tspan x="490.251" y="2854.023" fill="#000">2013</tspan> <tspan x="490.251" y="2890.471" fill="#000">2014</tspan> <tspan x="490.251" y="2926.919" fill="#FFF">2015</tspan>
 			</text>
 			<g id="Mediawiki.Neutral.Hover-38-Copy-4" stroke="#36C" stroke-linejoin="square">
@@ -2024,7 +2024,7 @@
 			</g>
 			<path id="Rectangle-607-Copy-7" fill="#EAF3FF" d="M293 2631h42v32h-42z"/>
 			<path id="Line-Copy-22" fill="#FFF" stroke="#72777D" d="M197 2663.5h348"/>
-			<text id="Tue-Nov-5,-2015" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2015" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="216" y="2653">Tue Nov 5, 2015</tspan>
 			</text>
 			<path id="Imported-Layers-61-Copy-7" fill="#000" d="M515.863 2693.35a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.018l-.578.534 7.5 6.956 7.5-6.956-.578-.543z" transform="matrix(1 0 0 -1 0 5393.92)"/>
@@ -2032,38 +2032,38 @@
 			<rect id="Mediawiki.Neutral.Acive-copy-17" width="10" height="10" x="456.596" y="2691.46" fill="#000" rx="2"/>
 			<ellipse id="Oval-221-Copy" cx="461.596" cy="2696.46" stroke="#000" stroke-width="2" rx="12.5" ry="10" transform="rotate(-14 461.596 2696.46)"/>
 			<rect id="Mediawiki.Neutral.Hover-37-Copy" width="201" height="31" x="654.5" y="2629.5" fill="#FFF" stroke="#54595D" rx="2"/>
-			<text id="Select-a-date" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Select-a-date" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="668" y="2651">Select a date</tspan>
 			</text>
 			<rect id="Mediawiki.Neutral.Acive-copy-24" width="20" height="20" x="822" y="2634" fill="#222" rx="2"/>
-			<text id="Hover" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Hover" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="202.251" y="406.201">Hover</tspan>
 			</text>
-			<text id="Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="423.251" y="406.201">Active</tspan>
 			</text>
-			<text id="Focus" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Focus" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="644.251" y="406.201">Focus</tspan>
 			</text>
-			<text id="Hover" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Hover" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="201.251" y="859.201">Hover</tspan>
 			</text>
-			<text id="Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="422.251" y="859.201">Active</tspan>
 			</text>
-			<text id="Focus" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Focus" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="1014.251" y="859.201">Focus</tspan>
 			</text>
-			<text id="Calendar-Expanded" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Calendar-Expanded" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="648.251" y="859.201">Calendar Expanded</tspan>
 			</text>
-			<text id="User-will-be-able-to" fill="#54595D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="User-will-be-able-to" fill="#54595D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="423.251" y="278.24">User will be able to press </tspan> <tspan x="423.251" y="296.24" font-family="LucidaGrande, Lucida Grande">↑</tspan> <tspan x="432.281" y="296.24"> to enter previous year,</tspan> <tspan x="423.251" y="314.24" font-family="LucidaGrande, Lucida Grande">↓</tspan> <tspan x="432.281" y="314.24"> to enter year after</tspan> <tspan x="423.251" y="350.24">User will also be able to type</tspan> <tspan x="423.251" y="368.24">the year manually.</tspan>
 			</text>
 			<text id="↑-to-enter-previous-" fill="#54595D" font-family="LucidaGrande, Lucida Grande" font-size="14" font-weight="normal">
-				<tspan x="647.251" y="261.24">↑</tspan> <tspan x="656.281" y="261.24" font-family="Lato-Regular, Lato"> to enter previous month if </tspan> <tspan x="647.251" y="279.24" font-family="Lato-Regular, Lato">cursor is over “Nov”,</tspan> <tspan x="647.251" y="297.24">↓</tspan> <tspan x="656.281" y="297.24" font-family="Lato-Regular, Lato"> to enter day after if cursor</tspan> <tspan x="647.251" y="315.24" font-family="Lato-Regular, Lato">is over “5”</tspan> <tspan x="647.251" y="351.24" font-family="Lato-Regular, Lato">User will also be able to type</tspan> <tspan x="647.251" y="369.24" font-family="Lato-Regular, Lato">the month and day manually.</tspan>
+				<tspan x="647.251" y="261.24">↑</tspan> <tspan x="656.281" y="261.24" font-family="Lato-Regular, Lato, sans-serif"> to enter previous month if </tspan> <tspan x="647.251" y="279.24" font-family="Lato-Regular, Lato, sans-serif">cursor is over “Nov”,</tspan> <tspan x="647.251" y="297.24">↓</tspan> <tspan x="656.281" y="297.24" font-family="Lato-Regular, Lato, sans-serif"> to enter day after if cursor</tspan> <tspan x="647.251" y="315.24" font-family="Lato-Regular, Lato, sans-serif">is over “5”</tspan> <tspan x="647.251" y="351.24" font-family="Lato-Regular, Lato, sans-serif">User will also be able to type</tspan> <tspan x="647.251" y="369.24" font-family="Lato-Regular, Lato, sans-serif">the month and day manually.</tspan>
 			</text>
-			<text id="Placeholder-icon-for" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="Placeholder-icon-for" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="1187" y="135.552">Placeholder icon for calendar</tspan>
 			</text>
 			<rect id="Mediawiki.Neutral.Acive-copy-22" width="20" height="20" x="1136" y="122" fill="#222" rx="2"/>
@@ -2074,19 +2074,19 @@
 			</g>
 			<rect id="Mediawiki.Neutral.Acive-copy-27" width="20" height="20" x="512" y="1477" fill="#222" rx="2"/>
 			<rect id="Rectangle-605-Copy-6" width="166" height="35" x="380.5" y="1707.5" fill="#36C" stroke="#36C" rx="2"/>
-			<text id="January---01-Copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="January---01-Copy" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="222" y="1585">January 01</tspan> <tspan x="222" y="1621.448">February 02</tspan> <tspan x="222" y="1657.896">March 03</tspan> <tspan x="222" y="1694.344">April 04</tspan> <tspan x="222" y="1730.792">May 05</tspan> <tspan x="222" y="1767.24">June 06</tspan>
 			</text>
-			<text id="July---07" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="July---07" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="401" y="1585" fill="#000">July 07</tspan> <tspan x="401" y="1621.448" fill="#000">August 08</tspan> <tspan x="401" y="1657.896" fill="#000">September 09</tspan> <tspan x="401" y="1694.344" fill="#000">October 10</tspan> <tspan x="401" y="1730.792" fill="#FFF">November 11</tspan> <tspan x="401" y="1767.24" fill="#000">December 12</tspan>
 			</text>
 			<path id="Line-Copy-43" fill="#FFF" stroke="#72777D" d="M204 1502.5h347"/>
 			<path id="Rectangle-607-Copy-8" fill="#EAF3FF" d="M251 1470h30v32h-30z"/>
-			<text id="Tue-Nov-14,-2013" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-14,-2013" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="222" y="1493">Tue Nov 14, 2013</tspan>
 			</text>
 			<path id="Imported-Layers-60-Copy-5" fill="#000" d="M230.422 1533.39a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.563-.52-1.47-.502-2.032.018l-.578.535 7.5 6.956 7.5-6.956-.578-.544z" transform="rotate(90 223.5 1537)"/>
-			<text id="Type-something-Copy-4" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Type-something-Copy-4" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="239.208" y="1542">2013</tspan>
 			</text>
 			<g id="Mediawiki.Neutral.Acive-copy-17-+-Oval-221-Copy-Copy-Copy-Copy-Copy-Copy" transform="translate(508 1525)">
@@ -2105,35 +2105,35 @@
 			<rect id="Rectangle-608-Copy" width="47" height="35" x="824.5" y="1672.5" stroke="#165C91" rx="2"/>
 			<path id="Line-214-Copy-2" stroke="#D0021B" stroke-width="4" d="M608.251 903.24h16"/>
 			<rect id="Mediawiki.Neutral.Acive-copy-33" width="20" height="20" x="589.251" y="892.24" fill="#222" rx="2"/>
-			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="695.808" y="1586" fill="#000">S</tspan> <tspan x="692.104" y="1622.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">28</tspan> <tspan x="696.552" y="1658.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">4</tspan> <tspan x="692.104" y="1695.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">11</tspan> <tspan x="692.104" y="1731.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">18</tspan> <tspan x="692.104" y="1768.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">25</tspan>
+			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="695.808" y="1586" fill="#000">S</tspan> <tspan x="692.104" y="1622.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">28</tspan> <tspan x="696.552" y="1658.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">4</tspan> <tspan x="692.104" y="1695.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">11</tspan> <tspan x="692.104" y="1731.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">18</tspan> <tspan x="692.104" y="1768.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">25</tspan>
 			</text>
-			<text id="M" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="742.744" y="1586" fill="#000">M</tspan> <tspan x="741.104" y="1622.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">29</tspan> <tspan x="745.552" y="1658.912" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">5</tspan> <tspan x="741.104" y="1695.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">12</tspan> <tspan x="741.104" y="1731.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">19</tspan> <tspan x="741.104" y="1768.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">26</tspan>
+			<text id="M" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="742.744" y="1586" fill="#000">M</tspan> <tspan x="741.104" y="1622.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">29</tspan> <tspan x="745.552" y="1658.912" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">5</tspan> <tspan x="741.104" y="1695.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">12</tspan> <tspan x="741.104" y="1731.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">19</tspan> <tspan x="741.104" y="1768.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">26</tspan>
 			</text>
-			<text id="T" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="794.112" y="1586" fill="#000">T</tspan> <tspan x="790.104" y="1622.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">30</tspan> <tspan x="794.552" y="1658.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">6</tspan> <tspan x="790.104" y="1695.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">13</tspan> <tspan x="790.104" y="1731.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">20</tspan> <tspan x="790.104" y="1768.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">27</tspan>
+			<text id="T" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="794.112" y="1586" fill="#000">T</tspan> <tspan x="790.104" y="1622.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">30</tspan> <tspan x="794.552" y="1658.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">6</tspan> <tspan x="790.104" y="1695.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">13</tspan> <tspan x="790.104" y="1731.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">20</tspan> <tspan x="790.104" y="1768.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">27</tspan>
 			</text>
 			<path id="Rectangle-607-Copy-9" fill="#EAF3FF" d="M691 1470h26v32h-26z"/>
-			<text id="W" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="839.448" y="1586" fill="#000">W</tspan> <tspan x="838.104" y="1622.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">31</tspan> <tspan x="842.552" y="1658.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">7</tspan> <tspan x="838.104" y="1695.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">14</tspan> <tspan x="838.104" y="1731.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">21</tspan> <tspan x="838.104" y="1768.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">28</tspan>
+			<text id="W" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="839.448" y="1586" fill="#000">W</tspan> <tspan x="838.104" y="1622.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">31</tspan> <tspan x="842.552" y="1658.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">7</tspan> <tspan x="838.104" y="1695.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">14</tspan> <tspan x="838.104" y="1731.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">21</tspan> <tspan x="838.104" y="1768.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">28</tspan>
 			</text>
-			<text id="T-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="890.112" y="1586">T</tspan> <tspan x="890.552" y="1622.464" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">1</tspan> <tspan x="890.552" y="1658.912" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">8</tspan> <tspan x="886.104" y="1695.36" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">15</tspan> <tspan x="886.104" y="1731.808" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">22</tspan> <tspan x="886.104" y="1768.256" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">29</tspan>
+			<text id="T-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="890.112" y="1586">T</tspan> <tspan x="890.552" y="1622.464" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">1</tspan> <tspan x="890.552" y="1658.912" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">8</tspan> <tspan x="886.104" y="1695.36" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">15</tspan> <tspan x="886.104" y="1731.808" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">22</tspan> <tspan x="886.104" y="1768.256" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">29</tspan>
 			</text>
-			<text id="F-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="938.256" y="1586">F</tspan> <tspan x="938.552" y="1622.464" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">2</tspan> <tspan x="938.552" y="1658.912" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">9</tspan> <tspan x="934.104" y="1695.36" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">16</tspan> <tspan x="934.104" y="1731.808" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">23</tspan> <tspan x="934.104" y="1768.256" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">30</tspan>
+			<text id="F-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="938.256" y="1586">F</tspan> <tspan x="938.552" y="1622.464" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">2</tspan> <tspan x="938.552" y="1658.912" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">9</tspan> <tspan x="934.104" y="1695.36" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">16</tspan> <tspan x="934.104" y="1731.808" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">23</tspan> <tspan x="934.104" y="1768.256" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">30</tspan>
 			</text>
-			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="985.808" y="1586" fill="#000">S</tspan> <tspan x="986.552" y="1622.464" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">3</tspan> <tspan x="982.104" y="1658.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">10</tspan> <tspan x="982.104" y="1695.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">17</tspan> <tspan x="982.104" y="1731.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">24</tspan> <tspan x="986.552" y="1768.256" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">1</tspan>
+			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="985.808" y="1586" fill="#000">S</tspan> <tspan x="986.552" y="1622.464" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">3</tspan> <tspan x="982.104" y="1658.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">10</tspan> <tspan x="982.104" y="1695.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">17</tspan> <tspan x="982.104" y="1731.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">24</tspan> <tspan x="986.552" y="1768.256" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">1</tspan>
 			</text>
 			<path id="Imported-Layers-60-Copy-4" fill="#000" d="M699.867 1532.945a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.018l-.578.535 7.5 6.956 7.5-6.956-.578-.544z"/>
 			<path id="Imported-Layers-61-Copy-9" fill="#000" d="M998.422 1533.39a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.563-.52-1.47-.502-2.032.018l-.578.535 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(1 0 0 -1 0 3074)"/>
 			<path id="Imported-Layers-61-Copy-10" fill="#000" d="M900.422 1533.39a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.563-.52-1.47-.502-2.032.018l-.578.535 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(-1 0 0 1 1787 0)"/>
-			<text id="Tue-Nov-14,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-14,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="692" y="1492">Tue Nov 14, 2013</tspan>
 			</text>
-			<text id="November-2013-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="November-2013-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="709" y="1540">November 2013</tspan>
 			</text>
 			<ellipse id="Oval-221-Copy-4" cx="942.548" cy="1535.727" stroke="#555" stroke-width="2" rx="12.5" ry="10" transform="rotate(-14 942.548 1535.727)"/>
@@ -2145,35 +2145,35 @@
 			<rect id="Mediawiki.Neutral.Acive-copy-25" width="20" height="20" x="957" y="894" fill="#222" rx="2"/>
 			<rect id="Mediawiki.Neutral.Acive-copy-26" width="10" height="10" x="913.138" y="948" fill="#000" rx="2"/>
 			<rect id="Rectangle-605-Copy-3" width="47" height="35" x="701.638" y="1052.5" fill="#36C" stroke="#36C" rx="2"/>
-			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="670.946" y="1003" fill="#000">S</tspan> <tspan x="667.242" y="1039.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">28</tspan> <tspan x="671.69" y="1075.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">4</tspan> <tspan x="667.242" y="1112.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">11</tspan> <tspan x="667.242" y="1148.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">18</tspan> <tspan x="667.242" y="1185.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">25</tspan>
+			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="670.946" y="1003" fill="#000">S</tspan> <tspan x="667.242" y="1039.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">28</tspan> <tspan x="671.69" y="1075.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">4</tspan> <tspan x="667.242" y="1112.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">11</tspan> <tspan x="667.242" y="1148.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">18</tspan> <tspan x="667.242" y="1185.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">25</tspan>
 			</text>
-			<text id="M" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="717.882" y="1003" fill="#000">M</tspan> <tspan x="716.242" y="1039.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">29</tspan> <tspan x="720.69" y="1075.912" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">5</tspan> <tspan x="716.242" y="1112.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">12</tspan> <tspan x="716.242" y="1148.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">19</tspan> <tspan x="716.242" y="1185.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">26</tspan>
+			<text id="M" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="717.882" y="1003" fill="#000">M</tspan> <tspan x="716.242" y="1039.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">29</tspan> <tspan x="720.69" y="1075.912" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">5</tspan> <tspan x="716.242" y="1112.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">12</tspan> <tspan x="716.242" y="1148.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">19</tspan> <tspan x="716.242" y="1185.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">26</tspan>
 			</text>
-			<text id="T" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="769.25" y="1003" fill="#000">T</tspan> <tspan x="765.242" y="1039.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">30</tspan> <tspan x="769.69" y="1075.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">6</tspan> <tspan x="765.242" y="1112.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">13</tspan> <tspan x="765.242" y="1148.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">20</tspan> <tspan x="765.242" y="1185.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">27</tspan>
+			<text id="T" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="769.25" y="1003" fill="#000">T</tspan> <tspan x="765.242" y="1039.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">30</tspan> <tspan x="769.69" y="1075.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">6</tspan> <tspan x="765.242" y="1112.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">13</tspan> <tspan x="765.242" y="1148.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">20</tspan> <tspan x="765.242" y="1185.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">27</tspan>
 			</text>
-			<text id="W" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="814.586" y="1003" fill="#000">W</tspan> <tspan x="813.242" y="1039.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">31</tspan> <tspan x="817.69" y="1075.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">7</tspan> <tspan x="813.242" y="1112.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">14</tspan> <tspan x="813.242" y="1148.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">21</tspan> <tspan x="813.242" y="1185.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">28</tspan>
+			<text id="W" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="814.586" y="1003" fill="#000">W</tspan> <tspan x="813.242" y="1039.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">31</tspan> <tspan x="817.69" y="1075.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">7</tspan> <tspan x="813.242" y="1112.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">14</tspan> <tspan x="813.242" y="1148.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">21</tspan> <tspan x="813.242" y="1185.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">28</tspan>
 			</text>
-			<text id="T-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="865.25" y="1003">T</tspan> <tspan x="865.69" y="1039.464" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">1</tspan> <tspan x="865.69" y="1075.912" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">8</tspan> <tspan x="861.242" y="1112.36" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">15</tspan> <tspan x="861.242" y="1148.808" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">22</tspan> <tspan x="861.242" y="1185.256" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">29</tspan>
+			<text id="T-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="865.25" y="1003">T</tspan> <tspan x="865.69" y="1039.464" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">1</tspan> <tspan x="865.69" y="1075.912" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">8</tspan> <tspan x="861.242" y="1112.36" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">15</tspan> <tspan x="861.242" y="1148.808" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">22</tspan> <tspan x="861.242" y="1185.256" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">29</tspan>
 			</text>
-			<text id="F-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="913.394" y="1003">F</tspan> <tspan x="913.69" y="1039.464" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">2</tspan> <tspan x="913.69" y="1075.912" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">9</tspan> <tspan x="909.242" y="1112.36" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">16</tspan> <tspan x="909.242" y="1148.808" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">23</tspan> <tspan x="909.242" y="1185.256" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">30</tspan>
+			<text id="F-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="913.394" y="1003">F</tspan> <tspan x="913.69" y="1039.464" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">2</tspan> <tspan x="913.69" y="1075.912" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">9</tspan> <tspan x="909.242" y="1112.36" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">16</tspan> <tspan x="909.242" y="1148.808" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">23</tspan> <tspan x="909.242" y="1185.256" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">30</tspan>
 			</text>
-			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="960.946" y="1003" fill="#000">S</tspan> <tspan x="961.69" y="1039.464" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">3</tspan> <tspan x="957.242" y="1075.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">10</tspan> <tspan x="957.242" y="1112.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">17</tspan> <tspan x="957.242" y="1148.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">24</tspan> <tspan x="961.69" y="1185.256" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">1</tspan>
+			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="960.946" y="1003" fill="#000">S</tspan> <tspan x="961.69" y="1039.464" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">3</tspan> <tspan x="957.242" y="1075.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">10</tspan> <tspan x="957.242" y="1112.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">17</tspan> <tspan x="957.242" y="1148.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">24</tspan> <tspan x="961.69" y="1185.256" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">1</tspan>
 			</text>
 			<path id="Imported-Layers-60-Copy-4" fill="#000" d="M675.005 949.945a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.033.018l-.577.535 7.5 6.956 7.5-6.956-.578-.544z"/>
 			<path id="Imported-Layers-61-Copy-9" fill="#000" d="M973.56 950.39a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.018l-.578.535 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(1 0 0 -1 0 1908)"/>
 			<path id="Imported-Layers-61-Copy-10" fill="#000" d="M875.56 950.39a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.018l-.578.535 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(-1 0 0 1 1737.276 0)"/>
 			<path id="Rectangle-607-Copy-9" fill="#EAF3FF" d="M666.138 887h26v30h-26z"/>
-			<text id="Tue-Nov-5,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="667" y="909">Tue Nov 5, 2013</tspan>
 			</text>
-			<text id="November-2013-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="November-2013-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="684.138" y="961">November 2013</tspan>
 			</text>
 			<ellipse id="Oval-221-Copy-4" cx="917.686" cy="952.727" stroke="#555" stroke-width="2" rx="12.5" ry="10" transform="rotate(-14 917.686 952.727)"/>
@@ -2185,36 +2185,36 @@
 			<rect id="Mediawiki.Neutral.Acive-copy-25" width="20" height="20" x="511" y="2076" fill="#222" rx="2"/>
 			<rect id="Mediawiki.Neutral.Acive-copy-26" width="10" height="10" x="467" y="2131" fill="#000" rx="2"/>
 			<rect id="Rectangle-605-Copy-3" width="47" height="35" x="255.5" y="2235.5" fill="#36C" stroke="#36C" rx="2"/>
-			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="224.808" y="2186" fill="#000">S</tspan> <tspan x="221.104" y="2222.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">28</tspan> <tspan x="225.552" y="2258.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">4</tspan> <tspan x="221.104" y="2295.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">11</tspan> <tspan x="221.104" y="2331.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">18</tspan> <tspan x="221.104" y="2368.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">25</tspan>
+			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="224.808" y="2186" fill="#000">S</tspan> <tspan x="221.104" y="2222.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">28</tspan> <tspan x="225.552" y="2258.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">4</tspan> <tspan x="221.104" y="2295.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">11</tspan> <tspan x="221.104" y="2331.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">18</tspan> <tspan x="221.104" y="2368.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">25</tspan>
 			</text>
-			<text id="M" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="271.744" y="2186" fill="#000">M</tspan> <tspan x="270.104" y="2222.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">29</tspan> <tspan x="274.552" y="2258.912" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">5</tspan> <tspan x="270.104" y="2295.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">12</tspan> <tspan x="270.104" y="2331.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">19</tspan> <tspan x="270.104" y="2368.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">26</tspan>
+			<text id="M" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="271.744" y="2186" fill="#000">M</tspan> <tspan x="270.104" y="2222.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">29</tspan> <tspan x="274.552" y="2258.912" fill="#FFF" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">5</tspan> <tspan x="270.104" y="2295.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">12</tspan> <tspan x="270.104" y="2331.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">19</tspan> <tspan x="270.104" y="2368.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">26</tspan>
 			</text>
-			<text id="T" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="323.112" y="2186" fill="#000">T</tspan> <tspan x="319.104" y="2222.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">30</tspan> <tspan x="323.552" y="2258.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">6</tspan> <tspan x="319.104" y="2295.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">13</tspan> <tspan x="319.104" y="2331.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">20</tspan> <tspan x="319.104" y="2368.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">27</tspan>
+			<text id="T" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="323.112" y="2186" fill="#000">T</tspan> <tspan x="319.104" y="2222.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">30</tspan> <tspan x="323.552" y="2258.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">6</tspan> <tspan x="319.104" y="2295.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">13</tspan> <tspan x="319.104" y="2331.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">20</tspan> <tspan x="319.104" y="2368.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">27</tspan>
 			</text>
-			<text id="W" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="368.448" y="2186" fill="#000">W</tspan> <tspan x="367.104" y="2222.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">31</tspan> <tspan x="371.552" y="2258.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">7</tspan> <tspan x="367.104" y="2295.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">14</tspan> <tspan x="367.104" y="2331.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">21</tspan> <tspan x="367.104" y="2368.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">28</tspan>
+			<text id="W" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="368.448" y="2186" fill="#000">W</tspan> <tspan x="367.104" y="2222.464" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">31</tspan> <tspan x="371.552" y="2258.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">7</tspan> <tspan x="367.104" y="2295.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">14</tspan> <tspan x="367.104" y="2331.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">21</tspan> <tspan x="367.104" y="2368.256" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">28</tspan>
 			</text>
-			<text id="T-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="419.112" y="2186">T</tspan> <tspan x="419.552" y="2222.464" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">1</tspan> <tspan x="419.552" y="2258.912" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">8</tspan> <tspan x="415.104" y="2295.36" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">15</tspan> <tspan x="415.104" y="2331.808" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">22</tspan> <tspan x="415.104" y="2368.256" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">29</tspan>
+			<text id="T-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="419.112" y="2186">T</tspan> <tspan x="419.552" y="2222.464" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">1</tspan> <tspan x="419.552" y="2258.912" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">8</tspan> <tspan x="415.104" y="2295.36" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">15</tspan> <tspan x="415.104" y="2331.808" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">22</tspan> <tspan x="415.104" y="2368.256" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">29</tspan>
 			</text>
-			<text id="F-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="467.256" y="2186">F</tspan> <tspan x="467.552" y="2222.464" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">2</tspan> <tspan x="467.552" y="2258.912" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">9</tspan> <tspan x="463.104" y="2295.36" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">16</tspan> <tspan x="463.104" y="2331.808" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">23</tspan> <tspan x="463.104" y="2368.256" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">30</tspan>
+			<text id="F-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="467.256" y="2186">F</tspan> <tspan x="467.552" y="2222.464" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">2</tspan> <tspan x="467.552" y="2258.912" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">9</tspan> <tspan x="463.104" y="2295.36" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">16</tspan> <tspan x="463.104" y="2331.808" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">23</tspan> <tspan x="463.104" y="2368.256" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">30</tspan>
 			</text>
-			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
-				<tspan x="514.808" y="2186" fill="#000">S</tspan> <tspan x="515.552" y="2222.464" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">3</tspan> <tspan x="511.104" y="2258.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">10</tspan> <tspan x="511.104" y="2295.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">17</tspan> <tspan x="511.104" y="2331.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">24</tspan> <tspan x="515.552" y="2368.256" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">1</tspan>
+			<text id="S" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
+				<tspan x="514.808" y="2186" fill="#000">S</tspan> <tspan x="515.552" y="2222.464" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">3</tspan> <tspan x="511.104" y="2258.912" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">10</tspan> <tspan x="511.104" y="2295.36" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">17</tspan> <tspan x="511.104" y="2331.808" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">24</tspan> <tspan x="515.552" y="2368.256" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">1</tspan>
 			</text>
 			<path id="Imported-Layers-60-Copy-4" fill="#000" d="M228.867 2132.945a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.018l-.578.535 7.5 6.956 7.5-6.956-.578-.544z"/>
 			<path id="Imported-Layers-61-Copy-9" fill="#000" d="M527.422 2133.39a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.563-.52-1.47-.502-2.032.018l-.578.535 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(1 0 0 -1 0 4274)"/>
 			<path id="Imported-Layers-61-Copy-10" fill="#000" d="M429.422 2133.39a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.563-.52-1.47-.502-2.032.018l-.578.535 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(-1 0 0 1 845 0)"/>
 			<path id="Rectangle-607-Copy-9" fill="#EAF3FF" d="M282 2071h13v31h-13z"/>
 			<path id="Line-Copy-42" fill="#FFF" stroke="#72777D" d="M202 2102.5h348"/>
-			<text id="Tue-Nov-5,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="221" y="2093">Tue Nov 5, 2013</tspan>
 			</text>
-			<text id="November-2013-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="November-2013-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="238" y="2143">November 2013</tspan>
 			</text>
 			<ellipse id="Oval-221-Copy-4" cx="471.548" cy="2135.727" stroke="#555" stroke-width="2" rx="12.5" ry="10" transform="rotate(-14 471.548 2135.727)"/>
@@ -2225,25 +2225,25 @@
 				<rect width="349" height="322.3" x="1117.096" y="1469.44" stroke="#36C" rx="2"/>
 			</g>
 			<rect id="Mediawiki.Neutral.Acive-copy-28" width="20" height="20" x="1425.596" y="1479.24" fill="#222" rx="2"/>
-			<text id="1986-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="1986-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1132.596" y="1584.94">1986</tspan> <tspan x="1132.596" y="1621.388">1987</tspan> <tspan x="1132.596" y="1657.836">1988</tspan> <tspan x="1132.596" y="1694.284">1989</tspan> <tspan x="1132.596" y="1730.732">1990</tspan> <tspan x="1132.596" y="1767.18">1991</tspan>
 			</text>
-			<text id="1992-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="1992-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1203.596" y="1584.94">1992</tspan> <tspan x="1203.596" y="1621.388">1993</tspan> <tspan x="1203.596" y="1657.836">1994</tspan> <tspan x="1203.596" y="1694.284">1995</tspan> <tspan x="1203.596" y="1730.732">1996</tspan> <tspan x="1203.596" y="1767.18">1997</tspan>
 			</text>
 			<rect id="Rectangle-608-Copy-6" width="59" height="35" x="1399.096" y="1671.44" fill="#36C" stroke="#36C" rx="2"/>
-			<text id="19981999-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="19981999-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1273.596" y="1584.94">1998</tspan> <tspan x="1273.596" y="1621.388">1999</tspan> <tspan x="1273.596" y="1657.836">2000</tspan> <tspan x="1273.596" y="1694.284">2001</tspan> <tspan x="1273.596" y="1730.732">2002</tspan> <tspan x="1273.596" y="1767.18">2003</tspan>
 			</text>
-			<text id="2004-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="2004-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1342.596" y="1584.94">2004</tspan> <tspan x="1342.596" y="1621.388">2005</tspan> <tspan x="1342.596" y="1657.836">2006</tspan> <tspan x="1342.596" y="1694.284">2007</tspan> <tspan x="1342.596" y="1730.732">2008</tspan> <tspan x="1342.596" y="1767.18">2009</tspan>
 			</text>
-			<text id="2010" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="2010" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1410.596" y="1584.94" fill="#000">2010</tspan> <tspan x="1410.596" y="1621.388" fill="#000">2011</tspan> <tspan x="1410.596" y="1657.836" fill="#000">2012</tspan> <tspan x="1410.596" y="1694.284" fill="#FFF">2013</tspan> <tspan x="1410.596" y="1730.732" fill="#000">2014</tspan> <tspan x="1410.596" y="1767.18" fill="#000">2015</tspan>
 			</text>
 			<path id="Line-Copy-45" stroke="#A2A9B1" stroke-linecap="square" d="M1118 1503.5h346"/>
 			<path id="Rectangle-607-Copy-10" fill="#EAF3FF" d="M1223 1471h41v32h-41z"/>
-			<text id="Tue-Nov-14,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-14,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="1135.596" y="1493.94">Tue Nov 14, 2013</tspan>
 			</text>
 			<path id="Imported-Layers-61-Copy-12" fill="#000" d="M1436.018 1534.33a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.019l-.578.534 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(1 0 0 -1 0 3075.88)"/>
@@ -2253,20 +2253,20 @@
 				<ellipse id="Oval-221-Copy" cx="15" cy="13.22" stroke="#000" stroke-width="2" rx="12.5" ry="10" transform="rotate(-14 15 13.22)"/>
 			</g>
 			<rect id="Mediawiki.Neutral.Acive-copy-28" width="20" height="20" x="954" y="437" fill="#000" rx="2"/>
-			<text id="1986-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="1986-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="659.596" y="544.94">1986</tspan> <tspan x="659.596" y="581.388">1987</tspan> <tspan x="659.596" y="617.836">1988</tspan> <tspan x="659.596" y="654.284">1989</tspan> <tspan x="659.596" y="690.732">1990</tspan> <tspan x="659.596" y="727.18">1991</tspan>
 			</text>
-			<text id="1992-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="1992-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="730.596" y="544.94">1992</tspan> <tspan x="730.596" y="581.388">1993</tspan> <tspan x="730.596" y="617.836">1994</tspan> <tspan x="730.596" y="654.284">1995</tspan> <tspan x="730.596" y="690.732">1996</tspan> <tspan x="730.596" y="727.18">1997</tspan>
 			</text>
 			<rect id="Rectangle-608-Copy-6" width="59" height="35" x="926.096" y="631.44" fill="#36C" stroke="#36C" rx="2"/>
-			<text id="19981999-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="19981999-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="800.596" y="544.94">1998</tspan> <tspan x="800.596" y="581.388">1999</tspan> <tspan x="800.596" y="617.836">2000</tspan> <tspan x="800.596" y="654.284">2001</tspan> <tspan x="800.596" y="690.732">2002</tspan> <tspan x="800.596" y="727.18">2003</tspan>
 			</text>
-			<text id="2004-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="2004-copy-2" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="869.596" y="544.94">2004</tspan> <tspan x="869.596" y="581.388">2005</tspan> <tspan x="869.596" y="617.836">2006</tspan> <tspan x="869.596" y="654.284">2007</tspan> <tspan x="869.596" y="690.732">2008</tspan> <tspan x="869.596" y="727.18">2009</tspan>
 			</text>
-			<text id="2010" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="2010" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="937.596" y="544.94" fill="#000">2010</tspan> <tspan x="937.596" y="581.388" fill="#000">2011</tspan> <tspan x="937.596" y="617.836" fill="#000">2012</tspan> <tspan x="937.596" y="654.284" fill="#FFF">2013</tspan> <tspan x="937.596" y="690.732" fill="#000">2014</tspan> <tspan x="937.596" y="727.18" fill="#000">2015</tspan>
 			</text>
 			<path id="Imported-Layers-61-Copy-13" fill="#000" d="M865.018 494.33a1.531 1.531 0 00-2.042 0l-4.88 4.495-4.89-4.504c-.564-.52-1.47-.502-2.032.019l-.578.534 7.5 6.956 7.5-6.956-.578-.544z" transform="matrix(-1 0 0 1 1716.192 0)"/>
@@ -2290,7 +2290,7 @@
 				<rect width="349" height="322" x="643.5" y="430.5" rx="2"/>
 			</g>
 			<path id="Rectangle-607-Copy-10" fill="#EAF3FF" d="M742 432h37v30h-37z"/>
-			<text id="Tue-Nov-5,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Tue-Nov-5,-2013" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="662" y="454">Tue Nov 5, 2013</tspan>
 			</text>
 			<path id="Line-Copy-42" fill="#FFF" stroke="#72777D" d="M673 1503h348.03"/>
@@ -2343,14 +2343,14 @@
 				</g>
 				<g id="Button-Toolbar-/-!default" transform="translate(199)">
 					<path id="Background/Border" fill="#FFF" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" d="M.5.5h79v41H.5z"/>
-					<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="14.36" y="27">Button</tspan>
 					</text>
 				</g>
 				<path id="Rectangle-4" fill="#36C" d="M279 0h106v42H279z"/>
 				<g id="Button-/---progressive-/-!default" transform="translate(280 4)">
 					<rect id="bg" width="103" height="35" x=".5" y=".5" fill="#36C" fill-rule="evenodd" stroke="#36C" stroke-width="1" rx="2"/>
-					<text id="label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="14.384" y="23.875">Primary…</tspan>
 					</text>
 				</g>
@@ -2358,7 +2358,7 @@
 			<g id="Toolbar-elements:hover" transform="translate(229 294)">
 				<g id="Button-Toolbar-/-:hover" transform="translate(199)">
 					<path id="Background/Border" fill="#F8F9FA" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" d="M.5.5h79v41H.5z"/>
-					<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="14.36" y="27">Button</tspan>
 					</text>
 				</g>
@@ -2384,7 +2384,7 @@
 				<path id="Rectangle-4" fill="#36C" d="M279 0h106v42H279z"/>
 				<g id="Button-/---progressive-/-!default" transform="translate(280 4)">
 					<rect id="bg" width="103" height="35" x=".5" y=".5" fill="#36C" fill-rule="evenodd" stroke="#36C" stroke-width="1" rx="2"/>
-					<text id="label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="14.384" y="23.875">Primary…</tspan>
 					</text>
 				</g>
@@ -2406,7 +2406,7 @@
 			<g id="Toolbar-elements:active" transform="translate(229 359)">
 				<g id="Button-Toolbar-/-:active" transform="translate(198 1)">
 					<path id="Background/Border" fill="#EAF3FF" fill-rule="evenodd" stroke="#EAECF0" stroke-width="1" d="M.5.5h79v39H.5z"/>
-					<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="14.36" y="26.476">Button</tspan>
 					</text>
 				</g>
@@ -2435,7 +2435,7 @@
 				<path id="Rectangle-4" fill="#36C" d="M279 0h106v42H279z"/>
 				<g id="Button-/---progressive-/-!default" transform="translate(280 4)">
 					<rect id="bg" width="103" height="35" x=".5" y=".5" fill="#36C" fill-rule="evenodd" stroke="#36C" stroke-width="1" rx="2"/>
-					<text id="label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="14.384" y="23.875">Primary…</tspan>
 					</text>
 				</g>
@@ -2448,7 +2448,7 @@
 						<path fill="#FFF" stroke="#36C" stroke-linejoin="square" stroke-width="2" d="M1 1h78v40H1z"/>
 						<path stroke="#36C" stroke-linejoin="square" d="M.5.5h79v41H.5z"/>
 					</g>
-					<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="14.36" y="27">Button</tspan>
 					</text>
 				</g>
@@ -2482,7 +2482,7 @@
 					<path stroke="#36C" stroke-width="2" d="M280 1h104v40H280z"/>
 					<path stroke="#36C" d="M279.5.5h105v41h-105z"/>
 				</g>
-				<text id="Primary…" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Primary…" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="294.384" y="28">Primary…</tspan>
 				</text>
 			</g>
@@ -2497,10 +2497,10 @@
 					<use fill="#000" filter="url(#filter-55)" xlink:href="#path-54"/>
 					<path fill="#FFF" stroke="#A2A9B1" stroke-linejoin="square" d="M203.5 42.5v88.493c0 .829.677 1.507 1.495 1.507h97.01c.824 0 1.495-.675 1.495-1.507V42.5h-100z"/>
 				</g>
-				<text id="Option-1-Copy" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+				<text id="Option-1-Copy" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="218.5" y="62.5">Option 1</tspan>
 				</text>
-				<text id="Option-2+3-Copy" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+				<text id="Option-2+3-Copy" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="218.5" y="93.5">Option 2</tspan> <tspan x="218.5" y="123.892">Option 3</tspan>
 				</text>
 				<g id="Icon-/-placeholder-(notBright/circle)-/-!default" fill="#222" transform="translate(156 11)">
@@ -2529,44 +2529,44 @@
 				<g id="Icon-/-Dropdown-indicator-/-:active" fill="#000" transform="translate(276 19)">
 					<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 				</g>
-				<text id="Option" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Option" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="218" y="27">Option</tspan>
 				</text>
 				<path id="Path-137" stroke="#CCC" d="M46.5 0v42"/>
 			</g>
-			<text id="“Currently-selected”" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="“Currently-selected”" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="482" y="136">“Currently selected” style</tspan>
 			</text>
-			<text id="Option-1-Copy" fill="#222" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Option-1-Copy" fill="#222" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="402" y="138">Option 1</tspan>
 			</text>
 			<path id="Line-164" stroke="#9013FE" stroke-width="4" d="M207 175v-15"/>
 			<path id="Line-165" stroke="#9013FE" stroke-width="4" d="M208 228v42"/>
 			<path id="Path-115" stroke="#CCC" stroke-dasharray="1" d="M614.5 204v295"/>
 			<circle id="Oval-229" cx="394.5" cy="133.5" r="2.5" fill="#36C"/>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="80">TOOLBAR</tspan>
 			</text>
 			<path id="Line-166" stroke="#222" stroke-linecap="square" d="M186.5 98.5H2.402"/>
-			<text id="Normal" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Normal" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="2" y="253.1">Normal</tspan>
 			</text>
-			<text id="Legend" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+			<text id="Legend" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 				<tspan x="2" y="140">Legend</tspan>
 			</text>
-			<text id="Hover" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Hover" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="2" y="318.1">Hover</tspan>
 			</text>
-			<text id="Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="2" y="384.1">Active</tspan>
 			</text>
-			<text id="Focus" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Focus" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="2" y="450.1">Focus</tspan>
 			</text>
-			<text id="8-sp-(0.5-em)" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="8-sp-(0.5-em)" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="230" y="137">8 sp (0.5 em)</tspan>
 			</text>
-			<text id="42-sp-height" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="42-sp-height" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="230" y="172">42 sp height</tspan>
 			</text>
 			<g id="_Spec-101-/-8-sp-(0.5-em)" stroke="#50E3C2" stroke-width="4" transform="translate(204.5 130)">
@@ -2574,7 +2574,7 @@
 			</g>
 		</g>
 		<g id="COMBOBOX-INPUT-FIELD" transform="translate(10190 803)">
-			<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="97">Normal</tspan> <tspan x="0" y="153.1">Hover</tspan> <tspan x="0" y="209.2">Active</tspan> <tspan x="0" y="265.3">Focus</tspan> <tspan x="0" y="321.4">Expanded Menu</tspan> <tspan x="0" y="489.7">Disabled</tspan>
 			</text>
 			<path id="Mediawiki.Neutral.Normal-copy-29" fill="#F8F9FA" stroke="#A2A9B1" d="M318.5 134.5v31h29.498c.832 0 1.502-.668 1.502-1.502v-27.996c0-.832-.668-1.502-1.502-1.502H318.5zm0 112v31h29.498c.832 0 1.502-.668 1.502-1.502v-27.996c0-.832-.668-1.502-1.502-1.502H318.5zm0-56v31h29.498c.832 0 1.502-.668 1.502-1.502v-27.996c0-.832-.668-1.502-1.502-1.502H318.5z"/>
@@ -2592,10 +2592,10 @@
 				<path d="M318.5 221.5v-31H201.99c-.825 0-1.49.667-1.49 1.502v27.996c0 .831.667 1.502 1.49 1.502H318.5z"/>
 			</g>
 			<path id="Line-Copy-12" stroke="#000" stroke-linecap="square" d="M290.5 254.5v16"/>
-			<text id="Placeholder" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Placeholder" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="208" y="156">Placeholder</tspan>
 			</text>
-			<text id="User-input" fill="#000" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="User-input" fill="#000" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="208" y="268">User input</tspan>
 			</text>
 			<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(328 481)">
@@ -2606,10 +2606,10 @@
 			</g>
 			<path id="Mediawiki.Neutral.Normal-copy-30" fill="#F8F9FA" stroke="#A2A9B1" d="M318.5 78.5v31h29.498c.832 0 1.502-.668 1.502-1.502V80.002c0-.832-.668-1.502-1.502-1.502H318.5z"/>
 			<path id="Mediawiki.Neutral.Acive-8-Copy" fill="#FFF" stroke="#A2A9B1" d="M318.5 109.5v-31H201.99c-.825 0-1.49.667-1.49 1.502v27.996c0 .831.667 1.502 1.49 1.502H318.5z"/>
-			<text id="Placeholder-Copy" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Placeholder-Copy" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="208" y="100">Placeholder</tspan>
 			</text>
-			<text id="Placeholder" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Placeholder" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="208" y="491">Placeholder</tspan>
 			</text>
 			<g id="Icon-/-Dropdown-indicator-/-!default" fill="#222" transform="translate(328 91)">
@@ -2622,7 +2622,7 @@
 				<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 			</g>
 			<path id="Mediawiki.Neutral.Acive-8" fill="#FFF" stroke="#A2A9B1" d="M200.5 341.5h118v-31H201.99c-.825 0-1.49.667-1.49 1.502V341.5z"/>
-			<text id="Placeholder" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Placeholder" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="208" y="332">Placeholder</tspan>
 			</text>
 			<g id="Mediawiki.Neutral.Acive-20">
@@ -2636,10 +2636,10 @@
 			<g id="Icon-/-Dropdown-indicator-/-:active" fill="#000" transform="translate(328 323)">
 				<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 			</g>
-			<text id="Option-1" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Option-1" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="216" y="370">Option 1</tspan>
 			</text>
-			<text id="Option-2" fill="#111" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Option-2" fill="#111" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="216" y="408">Option 2</tspan>
 			</text>
 			<g id="_Spec-101-/-8-sp-(0.5-em)" stroke="#50E3C2" stroke-width="4" transform="rotate(90 -127.25 342.25)">
@@ -2663,17 +2663,17 @@
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(3 52)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">COMBOBOX INPUT FIELD</tspan>
 			</text>
 			<path id="Line" stroke="#C8CCD1" stroke-linecap="square" d="M318.5 469.5v31"/>
 			<path id="Line-Copy-12" stroke="#000" stroke-linecap="square" d="M209.5 198.5v16"/>
 		</g>
 		<g id="BUTTON-+-DROPDOWN" transform="translate(8580 760)">
-			<text id="BUTTON-+" fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text id="BUTTON-+" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">BUTTON +</tspan> <tspan x="0" y="80">DROPDOWN</tspan>
 			</text>
-			<text id="Disabled-Normal-Hove" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Disabled-Normal-Hove" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="148">Disabled</tspan> <tspan x="0" y="222.8">Normal</tspan> <tspan x="0" y="297.6">Hover</tspan> <tspan x="0" y="372.4">Active</tspan> <tspan x="0" y="447.2">Expanded Menu</tspan>
 			</text>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 96)">
@@ -2681,8 +2681,8 @@
 			</g>
 			<path id="Mediawiki.Neutral.Normal-copy-71" fill="#447FF5" stroke="#447FF5" d="M382.837 311.5v-47H194.003c-.83 0-1.503.672-1.503 1.501V310c0 .83.672 1.501 1.503 1.501h188.834z"/>
 			<path id="Mediawiki.Neutral.Normal-copy-72" fill="#36C" stroke="#36C" d="M384.5 264.5v47h31.902a1.5 1.5 0 001.498-1.501V266c0-.826-.675-1.501-1.498-1.501H384.5z"/>
-			<text id="Download-original-fi-14" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="206" y="283">Download original file</tspan> <tspan x="206" y="300.406" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Download-original-fi-14" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="206" y="283">Download original file</tspan> <tspan x="206" y="300.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
 			<path id="Line-42" stroke="#FFF" stroke-linecap="square" d="M383.5 263.5v49"/>
 			<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(395 285)">
@@ -2690,8 +2690,8 @@
 			</g>
 			<path id="Mediawiki.Neutral.Normal-copy-81" fill="#36C" stroke="#36C" d="M382.837 239.5v-47H194.003c-.83 0-1.503.672-1.503 1.501V238c0 .83.672 1.501 1.503 1.501h188.834z"/>
 			<path id="Mediawiki.Neutral.Normal-copy-79" fill="#36C" stroke="#36C" d="M384.5 192.5v47h31.902a1.5 1.5 0 001.498-1.501V194c0-.826-.675-1.501-1.498-1.501H384.5z"/>
-			<text id="Download-original-fi-14-Copy" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="206" y="211">Download original file</tspan> <tspan x="206" y="228.406" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Download-original-fi-14-Copy" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="206" y="211">Download original file</tspan> <tspan x="206" y="228.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
 			<path id="Line-42-Copy" stroke="#FFF" stroke-linecap="square" d="M383.5 191.5v49"/>
 			<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(395 213)">
@@ -2699,7 +2699,7 @@
 			</g>
 			<path id="Mediawiki.Neutral.Normal-copy-84" fill="#C8CCD1" stroke="#C8CCD1" d="M382.837 167.5v-47H194.003c-.83 0-1.503.672-1.503 1.501V166c0 .83.672 1.501 1.503 1.501h188.834z"/>
 			<path id="Mediawiki.Neutral.Normal-copy-82" fill="#C8CCD1" stroke="#C8CCD1" d="M384.5 120.5v47h31.902a1.5 1.5 0 001.498-1.501V122c0-.826-.675-1.501-1.498-1.501H384.5z"/>
-			<text id="Download-original-fi-14-Copy-2" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Download-original-fi-14-Copy-2" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="206" y="141">Download original file</tspan> <tspan x="206" y="160.464">601 x 601 px jpg</tspan>
 			</text>
 			<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(395 141)">
@@ -2707,8 +2707,8 @@
 			</g>
 			<path id="Mediawiki.Neutral.Normal-copy-76" fill="#36C" stroke="#36C" d="M640.837 311.5v-47H452.003c-.83 0-1.503.672-1.503 1.501V310c0 .83.672 1.501 1.503 1.501h188.834z"/>
 			<path id="Mediawiki.Neutral.Normal-copy-75" fill="#447FF5" stroke="#447FF5" d="M642.5 264.5v47h31.902a1.5 1.5 0 001.498-1.501V266c0-.826-.675-1.501-1.498-1.501H642.5z"/>
-			<text id="Download-original-fi-16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="464" y="283">Download original file</tspan> <tspan x="464" y="300.406" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Download-original-fi-16" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="464" y="283">Download original file</tspan> <tspan x="464" y="300.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
 			<path id="Line-44" stroke="#FFF" stroke-linecap="square" d="M641.5 263.5v49"/>
 			<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(653 285)">
@@ -2716,8 +2716,8 @@
 			</g>
 			<path id="Mediawiki.Neutral.Normal-copy-78" fill="#36C" stroke="#36C" d="M640.837 383.5v-47H452.003c-.83 0-1.503.672-1.503 1.501V382c0 .83.672 1.501 1.503 1.501h188.834z"/>
 			<path id="Mediawiki.Neutral.Normal-copy-77" fill="#2A4B8D" stroke="#2A4B8D" d="M642.5 336.5v47h31.902a1.5 1.5 0 001.498-1.501V338c0-.826-.675-1.501-1.498-1.501H642.5z"/>
-			<text id="Download-original-fi-17" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="464" y="354.882">Download original file</tspan> <tspan x="464" y="372.288" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Download-original-fi-17" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="464" y="354.882">Download original file</tspan> <tspan x="464" y="372.288" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
 			<path id="Line-45" stroke="#FFF" stroke-linecap="square" d="M641.5 335.382v49"/>
 			<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(653 357)">
@@ -2725,8 +2725,8 @@
 			</g>
 			<path id="Mediawiki.Neutral.Normal-copy-74" fill="#2A4B8D" stroke="#2A4B8D" d="M382.837 383.5v-47H194.003c-.83 0-1.503.672-1.503 1.501V382c0 .83.672 1.501 1.503 1.501h188.834z"/>
 			<path id="Mediawiki.Neutral.Normal-copy-73" fill="#36C" stroke="#36C" d="M384.5 336.5v47h31.902a1.5 1.5 0 001.498-1.501V338c0-.826-.675-1.501-1.498-1.501H384.5z"/>
-			<text id="Download-original-fi-15" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="206" y="354.882">Download original file</tspan> <tspan x="206" y="372.288" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Download-original-fi-15" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="206" y="354.882">Download original file</tspan> <tspan x="206" y="372.288" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
 			<path id="Line-43" stroke="#FFF" stroke-linecap="square" d="M383.5 335.382v49"/>
 			<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(395 357)">
@@ -2738,14 +2738,14 @@
 				<path fill="#FFF" stroke="#A2A9B1" stroke-linejoin="square" d="M450.5 456.5v89.493a1.5 1.5 0 001.505 1.507h221.99c.832 0 1.505-.673 1.505-1.507V456.5h-225z"/>
 			</g>
 			<path id="Rectangle-320" fill="#36C" stroke="#36C" d="M450.5 455.5h189v-47H452.005c-.832 0-1.505.672-1.505 1.501V455.5z"/>
-			<text id="Original-file" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="464" y="477">Original file</tspan> <tspan x="464" y="494.406" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">601</tspan> <tspan x="487.352" y="494.406"> </tspan> <tspan x="491.244" y="494.406" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">x</tspan> <tspan x="498.496" y="494.406"> </tspan> <tspan x="502.388" y="494.406" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">601</tspan> <tspan x="525.74" y="494.406"> </tspan> <tspan x="529.632" y="494.406" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">px</tspan> <tspan x="545.186" y="494.406"> </tspan> <tspan x="549.078" y="494.406" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">jpg</tspan>
+			<text id="Original-file" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="464" y="477">Original file</tspan> <tspan x="464" y="494.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">601</tspan> <tspan x="487.352" y="494.406"> </tspan> <tspan x="491.244" y="494.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">x</tspan> <tspan x="498.496" y="494.406"> </tspan> <tspan x="502.388" y="494.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">601</tspan> <tspan x="525.74" y="494.406"> </tspan> <tspan x="529.632" y="494.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">px</tspan> <tspan x="545.186" y="494.406"> </tspan> <tspan x="549.078" y="494.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">jpg</tspan>
 			</text>
-			<text id="Small" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="466" y="521">Small</tspan> <tspan x="466" y="538.406" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Small" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="466" y="521">Small</tspan> <tspan x="466" y="538.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
-			<text id="Download-original-fi-3" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="464" y="427">Download original file</tspan> <tspan x="464" y="444.406" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">601</tspan> <tspan x="484.016" y="444.406"> </tspan> <tspan x="487.908" y="444.406" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">x</tspan> <tspan x="494.124" y="444.406"> </tspan> <tspan x="498.016" y="444.406" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">601</tspan> <tspan x="518.032" y="444.406"> </tspan> <tspan x="521.924" y="444.406" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">px</tspan> <tspan x="535.256" y="444.406"> </tspan> <tspan x="539.148" y="444.406" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">jpg</tspan>
+			<text id="Download-original-fi-3" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="464" y="427">Download original file</tspan> <tspan x="464" y="444.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">601</tspan> <tspan x="484.016" y="444.406"> </tspan> <tspan x="487.908" y="444.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">x</tspan> <tspan x="494.124" y="444.406"> </tspan> <tspan x="498.016" y="444.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">601</tspan> <tspan x="518.032" y="444.406"> </tspan> <tspan x="521.924" y="444.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">px</tspan> <tspan x="535.256" y="444.406"> </tspan> <tspan x="539.148" y="444.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">jpg</tspan>
 			</text>
 			<path id="Line-38" stroke="#FFF" stroke-linecap="square" d="M641.5 407.5v47.515"/>
 			<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(653 429)">
@@ -2757,19 +2757,19 @@
 			</g>
 			<path id="Mediawiki.Neutral.Normal-copy-86" fill="#2A4B8D" stroke="#2A4B8D" d="M898.5 408.5v47h33v-45.499c0-.83-.67-1.501-1.5-1.501h-31.5z"/>
 			<path id="Rectangle-320-Copy" fill="#36C" stroke="#36C" d="M707.5 455.5h189v-47H709.005c-.832 0-1.505.672-1.505 1.501V455.5z"/>
-			<text id="Original-file-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="720" y="477">Original file</tspan> <tspan x="720" y="494.406" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Original-file-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="720" y="477">Original file</tspan> <tspan x="720" y="494.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
-			<text id="Download-original-fi-3-Copy" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="720" y="428">Download original file</tspan> <tspan x="720" y="445.406" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Download-original-fi-3-Copy" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="720" y="428">Download original file</tspan> <tspan x="720" y="445.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
 			<path id="Line-38-Copy" stroke="#FFF" stroke-linecap="square" d="M897.5 408v48"/>
 			<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(909 429)">
 				<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 			</g>
 			<path id="Rectangle-321" fill="#EAECF0" d="M708.996 504h221v42h-221z"/>
-			<text id="Small-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="720" y="522">Small</tspan> <tspan x="720" y="539.406" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Small-Copy" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="720" y="522">Small</tspan> <tspan x="720" y="539.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
 			<g id="Cursor-/-Pointer" transform="translate(902 525)">
 				<g id="Cursor-Pointer">
@@ -2784,14 +2784,14 @@
 			</g>
 			<path id="Rectangle-320-Copy-2" fill="#36C" stroke="#36C" d="M967.5 455.5h189v-47H969.005c-.832 0-1.505.672-1.505 1.501V455.5z"/>
 			<path id="Rectangle-321-Copy" fill="#EAF3FF" d="M968 503v44h222v-44z"/>
-			<text id="Original-file-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="981" y="477">Original file</tspan> <tspan x="981" y="494.406" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Original-file-Copy-2" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="981" y="477">Original file</tspan> <tspan x="981" y="494.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
-			<text id="Small-Copy-2" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="981" y="521">Small</tspan> <tspan x="981" y="538.406" font-family="HelveticaNeue, Helvetica Neue" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Small-Copy-2" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="981" y="521">Small</tspan> <tspan x="981" y="538.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
-			<text id="Download-original-fi-3-Copy-2" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="14" font-weight="bold">
-				<tspan x="980" y="428">Download original file</tspan> <tspan x="980" y="445.406" font-family="HelveticaNeue, Helvetica Neue" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
+			<text id="Download-original-fi-3-Copy-2" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="14" font-weight="bold">
+				<tspan x="980" y="428">Download original file</tspan> <tspan x="980" y="445.406" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="12" font-weight="normal">601 x 601 px jpg</tspan>
 			</text>
 			<path id="Line-38-Copy-2" stroke="#FFF" stroke-linecap="square" d="M1157.5 408.5v47.515"/>
 			<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(1169 429)">
@@ -2800,7 +2800,7 @@
 			<path id="Line-42-Copy" stroke="#FFF" stroke-linecap="square" d="M383.5 119v49"/>
 		</g>
 		<g id="ICON-DROPDOWN" transform="translate(10180 142)">
-			<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="135">Normal</tspan> <tspan x="0" y="191.1">Hover</tspan> <tspan x="0" y="247.2">Active</tspan> <tspan x="0" y="303.3">Expanded Menu</tspan> <tspan x="0" y="359.4"> </tspan> <tspan x="0" y="452.9">Focus</tspan> <tspan x="0" y="509">Disabled</tspan>
 			</text>
 			<path id="Rectangle-640-Copy-10" fill="#EAECF0" d="M192 337h36v29.998c0 1.106-.89 2.002-2 2.002h-32c-1.105 0-2-.89-2-2.002V337z" transform="matrix(1 0 0 -1 0 706)"/>
@@ -2811,7 +2811,7 @@
 				<use fill="#000" filter="url(#filter-70)" xlink:href="#path-69"/>
 				<path fill="#FFF" stroke="#A2A9B1" stroke-linejoin="square" d="M192.5 315.5v91.493c0 .832.675 1.507 1.503 1.507h83.994c.83 0 1.503-.675 1.503-1.507V315.5h-87z"/>
 			</g>
-			<text id="Option-1-Copy-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+			<text id="Option-1-Copy-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="208" y="334">Option 1</tspan> <tspan x="208" y="366">Option 2</tspan> <tspan x="208" y="398">Option 3</tspan>
 			</text>
 			<g id="_Spec-101-/-8-sp-(0.5-em)" stroke="#50E3C2" stroke-width="4" transform="rotate(90 -61 276)">
@@ -2886,15 +2886,15 @@
 			<g id="Icon-/-placeholder-(notBright/circle)-/-:hover" fill="#444" transform="translate(263 176)">
 				<path id="Shape" d="M10 0C4.477 0 0 4.477 0 10s4.477 10 10 10 10-4.477 10-10S15.523 0 10 0z"/>
 			</g>
-			<text id="20-sp-x-20-sp-icon-v" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+			<text id="20-sp-x-20-sp-icon-v" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 				<tspan x="308" y="185">20 sp x 20 sp icon</tspan> <tspan x="308" y="200">vertical-align: middle</tspan>
 			</text>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">ICON </tspan> <tspan x="0" y="80">DROPDOWN</tspan>
 			</text>
 		</g>
 		<g id="LINK-DROPDOWN" transform="translate(9460 142)">
-			<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="134">Normal</tspan> <tspan x="0" y="190.1">Hover</tspan> <tspan x="0" y="246.2">Active</tspan> <tspan x="0" y="302.3">Expanded Menu</tspan> <tspan x="0" y="414.5">Focus</tspan> <tspan x="0" y="470.6">Disabled</tspan>
 			</text>
 			<rect id="Mediawiki.Neutral.Acive-15-Copy-8" width="107" height="32" x="194" y="169" fill="#F8F9FA" rx="2"/>
@@ -2907,16 +2907,16 @@
 				<use fill="#000" filter="url(#filter-74)" xlink:href="#path-73"/>
 				<path fill="#FFF" stroke="#A2A9B1" stroke-linejoin="square" d="M194.5 313.443v59.508c0 .824.669 1.492 1.495 1.492h103.01a1.5 1.5 0 001.495-1.492v-59.508h-106z"/>
 			</g>
-			<text id="Neutral-26-Copy-4" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Neutral-26-Copy-4" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="209.652" y="137">Neutral</tspan>
 			</text>
-			<text id="Neutral" fill="#444" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Neutral" fill="#444" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="209" y="192">Neutral</tspan>
 			</text>
-			<text id="Neutral-26-Copy-6" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Neutral-26-Copy-6" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="209" y="248">Neutral</tspan>
 			</text>
-			<text id="Neutral-26-Copy-7" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Neutral-26-Copy-7" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="209" y="303">Neutral</tspan>
 			</text>
 			<g id="Icon-/-Dropdown-indicator-/-!default" fill="#222" transform="translate(275 127)">
@@ -2929,13 +2929,13 @@
 				<rect width="105" height="30" x="195" y="402" stroke-width="2" rx="2"/>
 				<rect width="106" height="31" x="194.5" y="401.5" rx="2"/>
 			</g>
-			<text id="Neutral-26-Copy-8" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Neutral-26-Copy-8" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="208.652" y="424">Neutral</tspan>
 			</text>
 			<g id="Icon-/-Dropdown-indicator-/-!default" fill="#222" transform="translate(275 414)">
 				<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 			</g>
-			<text id="Neutral-28-Copy" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Neutral-28-Copy" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="209" y="474">Neutral</tspan>
 			</text>
 			<g id="Icon-/-Dropdown-indicator-/-:disabled" fill="#949494" transform="translate(275 464)">
@@ -2947,10 +2947,10 @@
 			<g id="Icon-/-Dropdown-indicator-/-:active" fill="#000" transform="translate(275 294)">
 				<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 			</g>
-			<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+			<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="209" y="334">Neutral</tspan>
 			</text>
-			<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+			<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="209" y="364">Neutral 2</tspan>
 			</text>
 			<g id="Mediawiki.Neutral.Acive-15-Copy-13" stroke="#36C" stroke-linejoin="square">
@@ -3012,32 +3012,32 @@
 			</g>
 			<path id="Rectangle-631-Copy" fill="#EAECF0" d="M323 345h105v28.008c0 1.1-.892 1.992-2.004 1.992H325.004a2.002 2.002 0 01-2.004-1.992V345z"/>
 			<path id="Rectangle-633-Copy" fill="#EAF3FF" d="M451 345h105v28.008c0 1.1-.892 1.992-2.004 1.992H453.004a2.002 2.002 0 01-2.004-1.992V345z"/>
-			<text id="Neutral-26-Copy-9" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Neutral-26-Copy-9" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="337" y="302">Neutral</tspan>
 			</text>
 			<g id="Icon-/-Dropdown-indicator-/-:active" fill="#000" transform="translate(404 294)">
 				<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 			</g>
-			<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+			<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="338" y="334">Neutral</tspan>
 			</text>
-			<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+			<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="338" y="365">Neutral 2</tspan>
 			</text>
 			<g id="Mediawiki.Neutral.Acive-15-Copy-16" stroke="#36C" stroke-linejoin="square">
 				<path fill="#FFF" stroke-width="2" d="M451 312h105v-28.998a.998.998 0 00-.995-1.002h-103.01a.994.994 0 00-.995 1.002V312z"/>
 				<path d="M450.5 312.5h106v-29.498c0-.83-.67-1.502-1.495-1.502h-103.01c-.828 0-1.495.668-1.495 1.502V312.5z"/>
 			</g>
-			<text id="Neutral-26-Copy-10" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+			<text id="Neutral-26-Copy-10" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 				<tspan x="465.152" y="302">Neutral</tspan>
 			</text>
 			<g id="Icon-/-Dropdown-indicator-/-:active" fill="#000" transform="translate(532 294)">
 				<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 			</g>
-			<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+			<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="466" y="334">Neutral</tspan>
 			</text>
-			<text id="Neutral-2" fill="#36C" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+			<text id="Neutral-2" fill="#36C" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="466" y="365">Neutral 2</tspan>
 			</text>
 			<g id="_Spec-101-/-8-sp-(0.5-em)" stroke="#50E3C2" stroke-width="4" transform="translate(266 465)">
@@ -3049,7 +3049,7 @@
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 96)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">LINK </tspan> <tspan x="0" y="80">DROPDOWN</tspan>
 			</text>
 		</g>
@@ -3078,16 +3078,16 @@
 					<path fill="#FFF" stroke="#A2A9B1" stroke-linejoin="square" d="M192.5 200.5v61.497c0 .83.67 1.503 1.495 1.503h103.01c.822 0 1.495-.677 1.495-1.503V200.5h-106z"/>
 				</g>
 				<rect id="Mediawiki.Neutral.Acive-15" width="106" height="31" x="192.5" y=".5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
-				<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="207.652" y="23">Neutral</tspan>
 				</text>
-				<text id="Neutral-26" fill="#444" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Neutral-26" fill="#444" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="207" y="78">Neutral</tspan>
 				</text>
-				<text id="Neutral-26" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Neutral-26" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="207" y="134">Neutral</tspan>
 				</text>
-				<text id="Neutral-26" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Neutral-26" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="208.152" y="189">Neutral</tspan>
 				</text>
 				<g id="Icon-/-Dropdown-indicator-/-!default" fill="#222" transform="translate(273 13)">
@@ -3100,7 +3100,7 @@
 					<rect width="105" height="30" x="193" y="300" stroke-width="2" rx="2"/>
 					<rect width="106" height="31" x="192.5" y="299.5" rx="2"/>
 				</g>
-				<text id="Neutral-26-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Neutral-26-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="207.652" y="321">Neutral</tspan>
 				</text>
 				<g id="Icon-/-Dropdown-indicator-/-!default" fill="#222" transform="translate(273 312)">
@@ -3119,7 +3119,7 @@
 				<g id="_Spec-101-/-12-sp-(0.75-em)" stroke="#0082FF" stroke-width="4" transform="translate(285 182)">
 					<path id=".75em" d="M0 2h12"/>
 				</g>
-				<text id="Neutral" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Neutral" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="207" y="376">Neutral</tspan>
 				</text>
 				<g id="Icon-/-Dropdown-indicator-/-:inverted" fill="#FFF" transform="translate(273 368)">
@@ -3152,10 +3152,10 @@
 				<g id="_Spec-101-/-8-sp-(0.5-em)" stroke="#50E3C2" stroke-width="4" transform="translate(264 182)">
 					<path id="8-sp-(0.5-em)" d="M0 2h8"/>
 				</g>
-				<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+				<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="207" y="221">Neutral</tspan>
 				</text>
-				<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+				<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="208" y="253">Neutral 2</tspan>
 				</text>
 				<g id="Mediawiki.Neutral.Acive-15-Copy-5">
@@ -3167,16 +3167,16 @@
 					<path fill="#FFF" stroke-width="2" d="M453 199h105v-28.998a.998.998 0 00-.995-1.002h-103.01a.994.994 0 00-.995 1.002V199z"/>
 					<path d="M452.5 199.5h106v-29.498c0-.83-.67-1.502-1.495-1.502h-103.01c-.828 0-1.495.668-1.495 1.502V199.5z"/>
 				</g>
-				<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Neutral" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="469.152" y="191">Neutral</tspan>
 				</text>
 				<g id="Icon-/-Dropdown-indicator-/-:active" fill="#000" transform="translate(530 181)">
 					<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 				</g>
-				<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+				<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="468" y="222">Neutral</tspan>
 				</text>
-				<text id="Neutral-2" fill="#36C" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+				<text id="Neutral-2" fill="#36C" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="468" y="253">Neutral 2</tspan>
 				</text>
 				<g id="_Spec-101-/-8-sp-(0.5-em)" stroke="#50E3C2" stroke-width="4" transform="rotate(90 12.5 203.5)">
@@ -3205,16 +3205,16 @@
 						<path fill="#FFF" stroke="#A2A9B1" stroke-linejoin="square" d="M.5 32.5v60.493c0 .834.672 1.507 1.509 1.507H106.99c.837 0 1.509-.67 1.509-1.507V32.5H.5z"/>
 					</g>
 					<path id="Rectangle-631" fill="#EAECF0" fill-rule="evenodd" d="M1.01 64h106.98v29.002c0 .551-.453.998-.99.998H2a.995.995 0 01-.99-.998V64z"/>
-					<text id="Neutral-26-Copy-2" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Neutral-26-Copy-2" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="16.559" y="22">Neutral</tspan>
 					</text>
 					<g id="Icon-/-Dropdown-indicator-/-!default" fill="#222" fill-rule="evenodd" transform="translate(78.722 13)">
 						<path id="Shape" d="M12 1.264L10.842 0 6 4.632 1.264 0 0 1.264l6 6 6-6"/>
 					</g>
-					<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Neutral" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="16.148" y="53">Neutral</tspan>
 					</text>
-					<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Neutral-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="16.148" y="85">Neutral 2</tspan>
 					</text>
 					<ellipse id="Oval-243-Copy" cx="8.579" cy="48.5" fill="#36C" fill-rule="evenodd" rx="2.523" ry="2.5"/>
@@ -3226,14 +3226,14 @@
 					</g>
 				</g>
 				<circle id="Oval-243-Copy-2" cx="460.5" cy="215.5" r="2.5" fill="#36C"/>
-				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="20">Normal</tspan> <tspan x="0" y="76.1">Hover</tspan> <tspan x="0" y="132.2">Active</tspan> <tspan x="0" y="188.3">Expanded Menu</tspan> <tspan x="0" y="207">Focus</tspan> <tspan x="0" y="319.2">Focus</tspan> <tspan x="0" y="375.3">Disabled</tspan>
 				</text>
 			</g>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(1 52)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="1" y="36">DROPDOWN</tspan>
 			</text>
 		</g>
@@ -3241,23 +3241,23 @@
 			<g id="File-input" transform="translate(200 114)">
 				<rect id="Mediawiki.Neutral.Hover-32-Copy-2" width="459" height="31" x=".5" y=".5" fill="#FFF" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
 				<path id="Rectangle-640-Copy-20" fill="#F8F9FA" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" d="M345.5 31.5V.5h112.504c.827 0 1.496.672 1.496 1.502v27.996c0 .834-.667 1.502-1.496 1.502H345.5z"/>
-				<text id="Select-a-file" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Select-a-file" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="358.568" y="23">Select a file</tspan>
 				</text>
 			</g>
 			<g id="Button-/-!default-(--neutral)" transform="translate(703 114)">
 				<rect id="bg" width="139" height="31" x=".5" y=".5" fill="#F8F9FA" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
-				<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="25.568" y="22">Select a file</tspan>
 				</text>
 			</g>
-			<text id="Normal-Disabled" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Normal-Disabled" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="135">Normal </tspan> <tspan x="0" y="191.1">Disabled</tspan>
 			</text>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(2 97)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">FILE INPUT </tspan> <tspan x="0" y="80">FIELD</tspan>
 			</text>
 		</g>
@@ -3268,7 +3268,7 @@
 					<rect id="Mediawiki.Neutral.Hover-33" width="95" height="31" x=".5" y=".5" fill="#EAECF0" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1" rx="2"/>
 				</g>
 				<path id="Rectangle" fill="#EAECF0" d="M43 28h4v4h-4zM133 28h4v4h-4zM133 2h4v4h-4zM43 2h4v4h-4z"/>
-				<text id="100" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="100" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="58" y="23">100</tspan>
 				</text>
 				<g id="🔣-Icon/Interactions/Subtract" transform="translate(16 7)">
@@ -3314,7 +3314,7 @@
 				<rect id="border" width="95" height="31" x=".5" y=".5" fill="#FFF" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
 			</g>
 			<path id="Rectangle" fill="#FFF" d="M234 141h4v4h-4zM322 141h4v4h-4zM322 115h4v4h-4zM234 115h4v4h-4z"/>
-			<text id="100" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="100" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="249" y="137">100</tspan>
 			</text>
 			<g id="🔣-Icon/Interactions/Subtract" transform="translate(207 120)">
@@ -3335,13 +3335,13 @@
 					<path id="Rectangle-1" d="M0 0h20v20H0z"/>
 				</g>
 			</g>
-			<text id="Normal-Disabled" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Normal-Disabled" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="135">Normal </tspan> <tspan x="0" y="191.1">Disabled</tspan>
 			</text>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(2 97)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text id="NUMBER-INPUT-FIELD" fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text id="NUMBER-INPUT-FIELD" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">NUMBER</tspan> <tspan x="0" y="80">INPUT FIELD</tspan>
 			</text>
 		</g>
@@ -3351,7 +3351,7 @@
 					<g id="Text-input-/-!default" fill="#EAECF0" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1">
 						<rect id="Mediawiki.Neutral.Hover-35" width="271" height="127" x=".5" y=".5" rx="2"/>
 					</g>
-					<text id="Placeholder-text" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Placeholder-text" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="9" y="23"> Disabled textarea</tspan>
 					</text>
 				</g>
@@ -3380,25 +3380,25 @@
 						<path stroke="#FFF" d="M6.448 11.787l2.721 6.886c.273.675-.094 1.44-.79 1.72-.696.283-1.491-.013-1.765-.692l-2.708-6.853-2.483 2.963-.077.075c-.901.695-1.848.236-1.846-.902L-.474.669c0-.618.027-.82.271-1.028.4-.34.694-.163 1.14.298l10.66 10.157c.793.817.432 1.805-.782 1.933l-4.367-.242z"/>
 					</g>
 				</g>
-				<text id="Normal-Disabled" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Disabled" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="22">Normal</tspan> <tspan x="0" y="190.3">Disabled</tspan>
 				</text>
 			</g>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(1 59)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="1" y="36">TEXTAREA</tspan>
 			</text>
 		</g>
 		<g id="TEXT-INPUT-FIELDS" transform="translate(7359 142)">
 			<g id="Password-Input-Field" transform="translate(1 719)">
-				<text id="Normal-Hover-Focus-&amp;" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Hover-Focus-&amp;" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="60.1">Normal</tspan> <tspan x="0" y="116.2">Hover</tspan> <tspan x="0" y="172.3">Focus &amp;</tspan> <tspan x="0" y="191">Active</tspan> <tspan x="0" y="228.4">Disabled</tspan>
 				</text>
 				<g id="Text-field-w/-icon---hover-/-active" transform="translate(193 95)">
 					<rect id="Mediawiki.Neutral.Hover-14-Copy" width="271" height="31" x=".5" y=".5" fill="#FFF" stroke="#72777D" rx="2"/>
-					<text id="Password" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Password" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="9" y="22">Password</tspan>
 					</text>
 					<path id="Imported-Layers-50-Copy" fill="#000" d="M132.584 16.052v7.911c-.009.632-.455 1.335-1.203 2.047a9.12 9.12 0 01-1.222.975l-.026.017a.284.284 0 00-.086.396.295.295 0 00.403.085 9.725 9.725 0 00.42-.294 9.78 9.78 0 00.917-.767c.479-.456.853-.915 1.09-1.373.238.461.61.919 1.088 1.373a9.776 9.776 0 001.337 1.061.295.295 0 00.403-.085.284.284 0 00-.086-.396l-.026-.017a8.2 8.2 0 01-.361-.254 9.168 9.168 0 01-.861-.72c-.748-.713-1.194-1.416-1.203-2.03v-7.93h1.343a.29.29 0 00.291-.286.29.29 0 00-.291-.287h-1.343V7.567c0-.627.447-1.338 1.203-2.055a9.048 9.048 0 011.22-.967l.026-.016a.284.284 0 00.089-.397.294.294 0 00-.403-.087 9.3 9.3 0 00-.421.292c-.312.229-.624.485-.917.762-.478.454-.852.912-1.09 1.37-.236-.458-.61-.916-1.089-1.37a9.52 9.52 0 00-1.337-1.054.295.295 0 00-.403.087.284.284 0 00.089.397l.025.016c.023.014.049.032.078.052a9.048 9.048 0 011.144.916c.755.716 1.202 1.427 1.202 2.054v7.91h-1.5a.29.29 0 00-.292.288c0 .158.13.287.292.287h1.5"/>
@@ -3407,15 +3407,15 @@
 					<rect width="270" height="30" x="194" y="152" fill="#FFF" stroke-width="2" rx="2"/>
 					<rect width="271" height="31" x="193.5" y="151.5" rx="2"/>
 				</g>
-				<text id="******-copy-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="******-copy-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="202" y="174">******</tspan>
 				</text>
 				<path id="Mediawiki.Neutral.Hover-35-Copy-2" fill="#FFF" stroke="#A2A9B1" d="M194.995 39.5c-.828 0-1.495.668-1.495 1.502v27.996c0 .83.67 1.502 1.495 1.502h268.01c.828 0 1.495-.668 1.495-1.502V41.002c0-.83-.67-1.502-1.495-1.502h-268.01z"/>
-				<text id="Password" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="Password" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="202" y="61">Password</tspan>
 				</text>
 				<g id="_Spec-101-/-Headline--Sub">
-					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 						<tspan x="0" y="13">PASSWORD INPUT FIELD</tspan>
 					</text>
 					<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -3425,12 +3425,12 @@
 				<path id="Line-172-Copy" stroke="#000" stroke-linecap="square" d="M238 158.5v17.938"/>
 			</g>
 			<g id="Search-Input-Field-+-Icon" transform="translate(1 409)">
-				<text id="Normal-Hover-Focus-&amp;" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Hover-Focus-&amp;" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="60.1">Normal</tspan> <tspan x="0" y="116.2">Hover</tspan> <tspan x="0" y="172.3">Focus &amp;</tspan> <tspan x="0" y="191">Active</tspan> <tspan x="0" y="228.4">Disabled</tspan>
 				</text>
 				<g id="Text-field-w/-icon---hover-/-active" transform="translate(193 95)">
 					<rect id="Mediawiki.Neutral.Hover-14-Copy" width="271" height="31" x=".5" y=".5" fill="#FFF" stroke="#72777D" rx="2"/>
-					<text id="Search" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Search" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="38" y="22">Search</tspan>
 					</text>
 					<path id="Imported-Layers-50-Copy" fill="#000" d="M158.584 17.052v7.911c-.009.632-.455 1.335-1.203 2.047a9.12 9.12 0 01-1.222.975l-.026.017a.284.284 0 00-.086.396.295.295 0 00.403.085 9.725 9.725 0 00.42-.294 9.78 9.78 0 00.917-.767c.479-.456.853-.915 1.09-1.373.238.461.61.919 1.088 1.373a9.776 9.776 0 001.337 1.061.295.295 0 00.403-.085.284.284 0 00-.086-.396l-.026-.017a8.2 8.2 0 01-.361-.254 9.168 9.168 0 01-.861-.72c-.748-.713-1.194-1.416-1.203-2.03v-7.93h1.343a.29.29 0 00.291-.286.29.29 0 00-.291-.287h-1.343V8.567c0-.627.447-1.338 1.203-2.055a9.048 9.048 0 011.22-.967l.026-.016a.284.284 0 00.089-.397.294.294 0 00-.403-.087 9.3 9.3 0 00-.421.292c-.312.229-.624.485-.917.762-.478.454-.852.912-1.09 1.37-.236-.458-.61-.916-1.089-1.37a9.52 9.52 0 00-1.337-1.054.295.295 0 00-.403.087.284.284 0 00.089.397l.025.016c.023.014.049.032.078.052a9.048 9.048 0 011.144.916c.755.716 1.202 1.427 1.202 2.054v7.91h-1.5a.29.29 0 00-.292.288c0 .158.13.287.292.287h1.5"/>
@@ -3443,7 +3443,7 @@
 					<rect width="270" height="30" x="194" y="152" fill="#FFF" stroke-width="2" rx="2"/>
 					<rect width="271" height="31" x="193.5" y="151.5" rx="2"/>
 				</g>
-				<text id="Entering-search-term" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="Entering-search-term" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="230" y="173">Entering search terms</tspan>
 				</text>
 				<path id="Shape-Copy-8" fill="#222" d="M448 159c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm4 11l-1 1-3-3-3 3-1-1 3-3-3-3 1-1 3 3 3-3 1 1-3 3 3 3z"/>
@@ -3454,7 +3454,7 @@
 					<path id="8-sp-(0.5-em)" d="M0 2h8"/>
 				</g>
 				<path id="Mediawiki.Neutral.Hover-35-Copy-3" fill="#FFF" stroke="#A2A9B1" d="M194.995 39.5c-.828 0-1.495.668-1.495 1.502v27.996c0 .83.67 1.502 1.495 1.502h268.01c.828 0 1.495-.668 1.495-1.502V41.002c0-.83-.67-1.502-1.495-1.502h-268.01z"/>
-				<text id="Search" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="Search" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="230" y="61">Search</tspan>
 				</text>
 				<g id="Icon-/-Search-/-!default" fill="#222" fill-rule="nonzero" transform="translate(202 45)">
@@ -3462,7 +3462,7 @@
 				</g>
 				<g id="Text-input-+-icon-/-:disabled" transform="translate(193 208)">
 					<rect id="Widget-input-disabled" width="273" height="31" x=".5" y=".5" fill="#EAECF0" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1" rx="2"/>
-					<text id="Placeholder" fill="#949494" font-family="HelveticaNeue, Helvetica Neue" font-size="16.364" font-weight="normal">
+					<text id="Placeholder" fill="#949494" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16.364" font-weight="normal">
 						<tspan x="36.265" y="22">Search</tspan>
 					</text>
 					<g id="🔣-Icon/Interactions/search" transform="translate(9.066 6)">
@@ -3485,7 +3485,7 @@
 					<path id="8-sp-(0.5-em)" d="M0 2h8"/>
 				</g>
 				<g id="_Spec-101-/-Headline--Sub">
-					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 						<tspan x="0" y="13">SEARCH INPUT FIELD</tspan>
 					</text>
 					<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -3496,13 +3496,13 @@
 			<g id="Text-Input-X" transform="translate(1 114)">
 				<g id="Text-input-/-:disabled" transform="translate(192 168)">
 					<rect id="Mediawiki.Neutral.Hover-33" width="271" height="31" x=".5" y=".5" fill="#EAECF0" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1" rx="2"/>
-					<text id="Placeholder-text" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Placeholder-text" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="9" y="22">Placeholder text</tspan>
 					</text>
 				</g>
 				<g id="Textfield_active" transform="translate(192 56)">
 					<rect id="Mediawiki.Neutral.Hover-14" width="271" height="31" x=".5" y=".5" fill="#FFF" stroke="#72777D" rx="2"/>
-					<text id="Your-input" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Your-input" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="9" y="22">Your input</tspan>
 					</text>
 					<path id="Imported-Layers-50" fill="#000" d="M216.584 28.052v7.911c-.009.632-.455 1.335-1.203 2.047a9.12 9.12 0 01-1.222.975l-.026.017a.284.284 0 00-.086.396.295.295 0 00.403.085 9.725 9.725 0 00.42-.294 9.78 9.78 0 00.917-.767c.479-.456.853-.915 1.09-1.373.238.461.61.919 1.088 1.373a9.776 9.776 0 001.337 1.061.295.295 0 00.403-.085.284.284 0 00-.086-.396l-.026-.017a8.2 8.2 0 01-.361-.254 9.168 9.168 0 01-.861-.72c-.748-.713-1.194-1.416-1.203-2.03v-7.93h1.343a.29.29 0 00.291-.286.29.29 0 00-.291-.287h-1.343v-7.911c0-.627.447-1.338 1.203-2.055a9.048 9.048 0 011.22-.967l.026-.016a.284.284 0 00.089-.397.294.294 0 00-.403-.087 9.3 9.3 0 00-.421.292c-.312.229-.624.485-.917.762-.478.454-.852.912-1.09 1.37-.236-.458-.61-.916-1.089-1.37a9.52 9.52 0 00-1.337-1.054.295.295 0 00-.403.087.284.284 0 00.089.397l.025.016c.023.014.049.032.078.052a9.048 9.048 0 011.144.916c.755.716 1.202 1.427 1.202 2.054v7.91h-1.5a.29.29 0 00-.292.288c0 .158.13.287.292.287h1.5"/>
@@ -3512,7 +3512,7 @@
 						<rect width="270" height="30" x="1" y="1" stroke-width="2" rx="2"/>
 						<rect width="271" height="31" x=".5" y=".5" rx="2"/>
 					</g>
-					<text id="Providing-input" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Providing-input" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="9" y="21">Providing input</tspan>
 					</text>
 					<g id="🔣-Icon/20x20-sp-placeholder-transparent" transform="translate(247 10)">
@@ -3524,7 +3524,7 @@
 				</g>
 				<g id="Text-input-/-!default" transform="translate(192)">
 					<rect id="border" width="271" height="31" x=".5" y=".5" fill="#FFF" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
-					<text id="Placeholder-text" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Placeholder-text" fill="#72777D" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="9" y="22">Your input</tspan>
 					</text>
 				</g>
@@ -3548,14 +3548,14 @@
 						<path stroke="#FFF" d="M6.448 11.787l2.721 6.886c.273.675-.094 1.44-.79 1.72-.696.283-1.491-.013-1.765-.692l-2.708-6.853-2.483 2.963-.077.075c-.901.695-1.848.236-1.846-.902L-.474.669c0-.618.027-.82.271-1.028.4-.34.694-.163 1.14.298l10.66 10.157c.793.817.432 1.805-.782 1.933l-4.367-.242z"/>
 					</g>
 				</g>
-				<text id="Normal-Hover-Focus-&amp;" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Hover-Focus-&amp;" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="22">Normal</tspan> <tspan x="0" y="78.1">Hover</tspan> <tspan x="0" y="134.2">Focus &amp;</tspan> <tspan x="0" y="152.9">Active</tspan> <tspan x="0" y="190.3">Disabled</tspan>
 				</text>
 			</g>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(1 96)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="1" y="36">TEXT INPUT </tspan> <tspan x="1" y="80">FIELDS</tspan>
 			</text>
 		</g>
@@ -3566,20 +3566,20 @@
 						<path id="Mediawiki.Neutral.Hover-copy-28" d="M15.49-.5h29.02c8.827 0 15.99 7.166 15.99 16 0 8.838-7.158 16-15.99 16H15.49C6.663 31.5-.5 24.334-.5 15.5c0-8.838 7.158-16 15.99-16z"/>
 						<ellipse id="Oval-45-Copy-13" cx="17" cy="15.5" rx="10.5" ry="10.188"/>
 					</g>
-					<text id="Option-title-Copy-4" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Option-title-Copy-4" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="0" y="39.914">Option with a really long</tspan> <tspan x="0" y="60.306">label today</tspan>
 					</text>
-					<text id="Option-title-Copy-6" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Option-title-Copy-6" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="0" y="123.235">Second option</tspan>
 					</text>
-					<text id="Option-title-Copy-5" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Option-title-Copy-5" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="0" y="22.608">Option 1</tspan>
 					</text>
-					<text id="Option-title-Copy-7" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Option-title-Copy-7" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="0" y="105.705">Option 2</tspan>
 					</text>
 				</g>
-				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="21">Normal</tspan> <tspan x="0" y="77.1">Hover</tspan> <tspan x="0" y="133.2">Active</tspan> <tspan x="0" y="189.3">Focus</tspan> <tspan x="0" y="245.4">Disabled</tspan>
 				</text>
 				<g id="Toggle-switch-/-!default" fill="#FFF" stroke="#72777D" transform="translate(500 392)">
@@ -3602,7 +3602,7 @@
 				<g id="_Spec-101-/-8-sp-(0.5-em)" stroke="#50E3C2" stroke-width="4" transform="translate(192 224)">
 					<path id="8-sp-(0.5-em)" d="M0 2h8"/>
 				</g>
-				<text id="Minimum-16-sp-(1-em)" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="Minimum-16-sp-(1-em)" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="506" y="461.381">Minimum 16 sp (1 em) margin</tspan>
 				</text>
 				<g id="Toggle-switch-/-:on-/-:disabled" transform="translate(400 228)">
@@ -3652,11 +3652,11 @@
 					<path id="Mediawiki.Neutral.Hover-copy-28" d="M16-.5h28c9.113 0 16.5 7.387 16.5 16.5 0 9.114-7.387 16.5-16.5 16.5H16C6.887 32.5-.5 25.113-.5 16-.5 6.886 6.887-.5 16-.5z"/>
 					<circle id="Oval-45-Copy-13" cx="17" cy="16" r="10.5"/>
 				</g>
-				<text id="Option-5-Copy-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="Option-5-Copy-2" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="333" y="413">Option 2</tspan>
 				</text>
 				<path id="Line-Copy-98" fill="#979797" fill-rule="nonzero" d="M323 376.014v-1h4V341h-4v-1h9v1h-4v34.014h4v1h-9z"/>
-				<text id="`vertical-align:-mid" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="`vertical-align:-mid" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="124" y="363">`vertical-align: middle` one-liner text</tspan>
 				</text>
 				<g id="Toggle-switch-/-:on-/-!default" transform="translate(502 554)">
@@ -3732,26 +3732,26 @@
 				<path id="1em" stroke="#D0021B" stroke-width="4" d="M395 536v16"/>
 				<path id="Line-Copy-95" stroke="#50E3C2" stroke-dasharray="1 3" stroke-linecap="square" d="M335 552.5h202"/>
 			</g>
-			<text id="Switched-on" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Switched-on" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="393" y="417">Switched on</tspan>
 			</text>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 96)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text id="TOGGLE" fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text id="TOGGLE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">TOGGLE</tspan> <tspan x="0" y="80">SWITCH</tspan>
 			</text>
 		</g>
 		<g id="RADIO-BUTTONS---DESKTOP" transform="translate(5840 143)">
 			<g id="Radio-Buttons-X" transform="translate(0 113)">
 				<g id="Radio-/-!default" transform="translate(192 378)">
-					<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Option 2</tspan>
 					</text>
 					<path id="Oval-112-Copy-2" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" d="M12 27.5c6.351 0 11.5-5.149 11.5-11.5S18.351 4.5 12 4.5.5 9.649.5 16 5.649 27.5 12 27.5z"/>
 				</g>
 				<g id="Radio-/-!default" transform="translate(192 336)">
-					<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Option 1</tspan>
 					</text>
 					<path id="Oval-112-Copy-2" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" d="M12 27.5c6.351 0 11.5-5.149 11.5-11.5S18.351 4.5 12 4.5.5 9.649.5 16 5.649 27.5 12 27.5z"/>
@@ -3764,27 +3764,27 @@
 						<path id="Oval-112-Copy-2" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" d="M12 27.5c6.351 0 11.5-5.149 11.5-11.5S18.351 4.5 12 4.5.5 9.649.5 16 5.649 27.5 12 27.5z"/>
 					</g>
 					<path id="Rectangle" fill="#FFF" fill-rule="evenodd" d="M33 0h169v60H33z"/>
-					<text id="Option-title-Copy-4" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Option-title-Copy-4" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="33" y="46">Option with a really long</tspan> <tspan x="33" y="66.392">label today</tspan>
 					</text>
-					<text id="Option-title" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Option-title" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="27">Option title</tspan>
 					</text>
 				</g>
 				<g id="Radio-/-:disabled" transform="translate(192 224)">
-					<text id="8:16:8:16-copy-27" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="8:16:8:16-copy-27" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<circle id="Oval-112" cx="12" cy="16" r="11.5" fill="#C8CCD1" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1"/>
 				</g>
 				<g id="Radio-/-:hover" transform="translate(192 56)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<circle id="Oval-112" cx="12" cy="16" r="11.5" stroke="#2962CC" stroke-width="1"/>
 				</g>
 				<g id="Radio-/-:active" transform="translate(192 112)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="Oval-112" stroke="#2A4B8D" stroke-linejoin="square">
@@ -3792,14 +3792,14 @@
 						<circle cx="12" cy="16" r="11.5"/>
 					</g>
 				</g>
-				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="21">Normal</tspan> <tspan x="0" y="77.1">Hover</tspan> <tspan x="0" y="133.2">Active</tspan> <tspan x="0" y="189.3">Focus</tspan> <tspan x="0" y="245.4">Disabled</tspan>
 				</text>
-				<text id="Switched-on" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Switched-on" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="477" y="307">Switched on</tspan>
 				</text>
 				<g id="Radio-/-:checked-/-:disabled" transform="translate(480 224)">
-					<text id="Label" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="Oval-112-Copy-+-Oval-59-Copy" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -3808,18 +3808,18 @@
 					</g>
 				</g>
 				<g id="Radio-/-!default" transform="translate(192)">
-					<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<path id="Oval-112-Copy-2" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" d="M12 27.5c6.351 0 11.5-5.149 11.5-11.5S18.351 4.5 12 4.5.5 9.649.5 16 5.649 27.5 12 27.5z"/>
 				</g>
 				<g id="Radio-/-!default" transform="translate(192 642)">
-					<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="8:16:8:16-copy-22" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Radio label</tspan>
 					</text>
 					<path id="Oval-112-Copy-2" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" d="M12 27.5c6.351 0 11.5-5.149 11.5-11.5S18.351 4.5 12 4.5.5 9.649.5 16 5.649 27.5 12 27.5z"/>
 				</g>
-				<text id="touch-area-features" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="touch-area-features" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="384" y="665">touch area features `width: 2em;` `height: 2em;`</tspan>
 				</text>
 				<rect id="touch-area" width="32" height="32" x="191" y="642" fill="#C70070" fill-opacity=".4" rx="1" style="mix-blend-mode:multiply"/>
@@ -3835,7 +3835,7 @@
 					</g>
 				</g>
 				<g id="Radio-/-:focus" transform="translate(192 168)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="Oval-112-Copy-4" stroke="#36C" stroke-linejoin="square">
@@ -3844,7 +3844,7 @@
 					</g>
 				</g>
 				<g id="Radio-/-:checked-/-:focus" transform="translate(480 168)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="Oval-112-Copy-5-+-Oval-78" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -3857,7 +3857,7 @@
 					</g>
 				</g>
 				<g id="Radio-/-:checked-/-:active" transform="translate(480 112)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="Oval-112-Copy-6-+-Oval-59-Copy-3" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -3866,7 +3866,7 @@
 					</g>
 				</g>
 				<g id="Radio-/-:checked-/-:hover" transform="translate(480 56)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="Oval-112-+-Oval-59" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -3875,7 +3875,7 @@
 					</g>
 				</g>
 				<g id="Radio-/-:checked-/-!default" transform="translate(480)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="Oval-112-Copy-3-+-Oval-59-Copy-2" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -3891,15 +3891,15 @@
 						<path id="Oval-112-Copy-2" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" d="M12 27.5c6.351 0 11.5-5.149 11.5-11.5S18.351 4.5 12 4.5.5 9.649.5 16 5.649 27.5 12 27.5z"/>
 					</g>
 					<path id="Rectangle" fill="#FFF" fill-rule="evenodd" d="M33 0h169v60H33z"/>
-					<text id="Option-title-Copy-4" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Option-title-Copy-4" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="33" y="46">Option with a really long</tspan> <tspan x="33" y="66.392">label today</tspan>
 					</text>
-					<text id="Option-title" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Option-title" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="27">Option title</tspan>
 					</text>
 				</g>
 				<path id="Line-Copy-92" fill="#979797" fill-rule="nonzero" d="M373 370.014v-1h4V335h-4v-1h9v1h-4v34.014h4v1h-9z"/>
-				<text id="`vertical-align:-mid" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="`vertical-align:-mid" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="383" y="358">`vertical-align: middle`</tspan>
 				</text>
 				<g id="_Spec-101-/-16-sp-(1-em)" stroke="#D0021B" stroke-width="4" transform="rotate(-90 413 127)">
@@ -3947,14 +3947,14 @@
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 95)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text id="RADIO-BUTTON" fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text id="RADIO-BUTTON" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">RADIO</tspan> <tspan x="0" y="80">BUTTON</tspan>
 			</text>
 		</g>
 		<g id="CHECKBOX-DESKTOP" transform="translate(5038 186)">
 			<g id="Checkbox-indeterminate" transform="translate(2 787)">
 				<g id="Checkbox-/-:indeterminate:checked-/-!default" transform="translate(480 42)">
-					<text id="Neutral-point" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Neutral-point" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="23">Indeterminate – children </tspan> <tspan x="33" y="41.448">selected</tspan>
 					</text>
 					<g id="Checkbox" fill-rule="evenodd" stroke-width="1" transform="translate(0 5)">
@@ -3971,13 +3971,13 @@
 					</g>
 				</g>
 				<g id="Checkbox-/-!default" transform="translate(192 43)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>
 				</g>
 				<g id="_Spec-101-/-Headline--Sub">
-					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 						<tspan x="0" y="13">INTEDERMINATE</tspan>
 					</text>
 					<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -3988,14 +3988,14 @@
 			<g id="Checkbox-X" transform="translate(2 69)">
 				<path id="Line-Copy-86" stroke="#50E3C2" stroke-dasharray="1 3" stroke-linecap="square" d="M173 335.5h202"/>
 				<path id="Line-Copy-85" stroke="#50E3C2" stroke-dasharray="1 3" stroke-linecap="square" d="M173 370h202"/>
-				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="22.1">Normal</tspan> <tspan x="0" y="78.2">Hover</tspan> <tspan x="0" y="134.3">Active</tspan> <tspan x="0" y="190.4">Focus</tspan> <tspan x="0" y="246.5">Disabled</tspan>
 				</text>
-				<text id="Switched-on" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Switched-on" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="477" y="304">Switched on</tspan>
 				</text>
 				<g id="Checkbox-/-!default" transform="translate(192 378)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Option 2</tspan>
 					</text>
 					<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>
@@ -4012,7 +4012,7 @@
 					</g>
 				</g>
 				<g id="Checkbox-/-!default" transform="translate(192 337)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Option 1</tspan>
 					</text>
 					<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>
@@ -4024,7 +4024,7 @@
 					<path id="8-sp-(0.5-em)" d="M0 2h8"/>
 				</g>
 				<g id="Checkbox-/-:checked-/-:disabled" transform="translate(480 226)">
-					<text id="Label" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="Mediawiki.Neutral.Hover-copy-10-+-Imported-Layers-Copy-2" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -4035,7 +4035,7 @@
 					</g>
 				</g>
 				<g id="Checkbox-/-:checked-/-:hover" transform="translate(480 57)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="32" y="22">Neutral point</tspan>
 					</text>
 					<g id="Mediawiki.Neutral.Hover-copy-12-+-Imported-Layers-Copy-3" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -4046,7 +4046,7 @@
 					</g>
 				</g>
 				<g id="Checkbox-/-:checked-/-:active" transform="translate(480 113)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="checkbox:checked:active" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -4057,7 +4057,7 @@
 					</g>
 				</g>
 				<g id="Checkbox-/-:checked-/-:focus" transform="translate(480 169)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="checkbox:checked:focus" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -4072,7 +4072,7 @@
 					</g>
 				</g>
 				<g id="Checkbox-/-:checked-/-!default" transform="translate(480)">
-					<text id="Neutral-point" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Neutral-point" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="23">Neutral point</tspan>
 					</text>
 					<g id="Checkbox" fill-rule="evenodd" stroke-width="1" transform="translate(0 5)">
@@ -4083,25 +4083,25 @@
 					</g>
 				</g>
 				<g id="Checkbox-/-:disabled" transform="translate(192 226)">
-					<text id="Label" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<path id="checkbox" fill="#C8CCD1" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1" d="M2.005 4.5C1.174 4.5.5 5.173.5 6.005v19.99c0 .831.673 1.505 1.505 1.505h19.99c.831 0 1.505-.673 1.505-1.505V6.005c0-.831-.673-1.505-1.505-1.505H2.005z"/>
 				</g>
 				<g id="Checkbox-/-:active" transform="translate(192 113)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#2A4B8D" fill-rule="evenodd" stroke="#2A4B8D" stroke-width="1" rx="2"/>
 				</g>
 				<g id="Checkbox-/-:hover" transform="translate(192 57)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="32" y="22">Neutral point</tspan>
 					</text>
 					<rect id="checkbox" width="23" height="23" x=".5" y="4.5" stroke="#2962CC" stroke-width="1" rx="2"/>
 				</g>
 				<g id="Checkbox-/-:focus" transform="translate(192 169)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<g id="checkbox" stroke="#36C" stroke-linejoin="square">
@@ -4110,13 +4110,13 @@
 					</g>
 				</g>
 				<g id="Checkbox-/-!default" transform="translate(192 1)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Neutral point</tspan>
 					</text>
 					<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>
 				</g>
 				<g id="Checkbox-/-!default" transform="translate(192 643)">
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="22">Checkbox label</tspan>
 					</text>
 					<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>
@@ -4127,10 +4127,10 @@
 						<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>
 					</g>
 					<path id="Rectangle" fill="#FFF" fill-rule="evenodd" d="M32 0h170v61H32z"/>
-					<text id="Option-title-Copy-4" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Option-title-Copy-4" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="33" y="46">Option with a really long</tspan> <tspan x="33" y="66.392">label today</tspan>
 					</text>
-					<text id="Option-title" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Option-title" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="27">Option title</tspan>
 					</text>
 				</g>
@@ -4138,10 +4138,10 @@
 					<path id="16-sp-(1-em)" d="M0 2h16"/>
 				</g>
 				<path id="Line" fill="#979797" fill-rule="nonzero" d="M371 371.014v-1h4V336h-4v-1h9v1h-4v34.014h4v1h-9z"/>
-				<text id="`vertical-align:-mid" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="`vertical-align:-mid" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="381" y="358">`vertical-align: middle`</tspan>
 				</text>
-				<text id="touch-area-features" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="touch-area-features" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="381" y="666">touch area features `width: 2em;` `height: 2em;`</tspan>
 				</text>
 				<g id="Cursor-/-Pointer" transform="translate(497 133)">
@@ -4185,10 +4185,10 @@
 						<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>
 					</g>
 					<path id="Rectangle" fill="#FFF" fill-rule="evenodd" d="M32 0h170v61H32z"/>
-					<text id="Option-title-Copy-4" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="14" font-weight="normal">
+					<text id="Option-title-Copy-4" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="33" y="46">Option with a really long</tspan> <tspan x="33" y="66.392">label today</tspan>
 					</text>
-					<text id="Option-title" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+					<text id="Option-title" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 						<tspan x="33" y="27">Option 2</tspan>
 					</text>
 				</g>
@@ -4201,61 +4201,61 @@
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(2 52)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text id="CHECKBOX-–-DESKTOP" fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text id="CHECKBOX-–-DESKTOP" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="2" y="36">CHECKBOX</tspan>
 			</text>
 		</g>
 		<g id="TEXT-HIGHLIGHT" transform="translate(4560 143)">
-			<text id="Normal-Highlighted-H" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+			<text id="Normal-Highlighted-H" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 				<tspan x="0" y="134">Normal</tspan> <tspan x="0" y="190.1">Highlighted</tspan> <tspan x="0" y="246.2">Highlighted positive</tspan>
 			</text>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 96)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text id="Label-copy-13" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+			<text id="Label-copy-13" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 				<tspan x="195" y="135">Neutral point</tspan>
 			</text>
 			<g id="Text-/---highlighted" transform="translate(192 175)">
 				<path id="Rectangle-631" fill="#FFB60D" fill-opacity=".4" fill-rule="evenodd" d="M0 0h100v21H0z"/>
-				<text id="8:16:8:16-copy-14" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="8:16:8:16-copy-14" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="4" y="16">Neutral point</tspan>
 				</text>
 			</g>
 			<g id="Text-/---highlighted-positive" transform="translate(192 231)">
 				<path id="Rectangle-631" fill="#B7F430" fill-rule="evenodd" d="M0 0h100v21H0z"/>
-				<text id="8:16:8:16-copy-14" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="8:16:8:16-copy-14" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="4" y="16">Neutral point</tspan>
 				</text>
 			</g>
-			<text id="TEXT" fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text id="TEXT" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">TEXT</tspan> <tspan x="0" y="80">HIGHLIGHT</tspan>
 			</text>
 		</g>
 		<g id="LINK" transform="translate(4078 186)">
 			<g id="Link-X" transform="translate(2 76)">
-				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="16">Normal</tspan> <tspan x="0" y="72.1">Hover</tspan> <tspan x="0" y="90.8"> </tspan> <tspan x="0" y="128.2">Active</tspan> <tspan x="0" y="184.3">Focus</tspan> <tspan x="0" y="240.4">Disabled</tspan>
 				</text>
-				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="367.3">Normal</tspan> <tspan x="0" y="423.4">Hover</tspan> <tspan x="0" y="442.1"> </tspan> <tspan x="0" y="479.5">Active</tspan> <tspan x="0" y="535.6">Focus</tspan>
 				</text>
 				<g id="_Spec-101-/-Headline--Sub" transform="translate(0 297)">
-					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 						<tspan x="0" y="13">UNDERLINED LINK</tspan>
 					</text>
 					<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
 						<path id="Line" d="M189.484 1.5H.516"/>
 					</g>
 				</g>
-				<text id="Label-copy-5" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label-copy-5" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="192" y="239">Neutral point</tspan>
 				</text>
-				<text id="Label-copy" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label-copy" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="192" y="71">Neutral point</tspan>
 				</text>
 				<g id="Link-:hover" transform="translate(192 111)">
 					<g id="Link">
-						<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="0" y="16">Neutral point</tspan>
 						</text>
 						<path id="Line" stroke="#36C" stroke-linecap="square" d="M1.5 18.5h57.46"/>
@@ -4264,7 +4264,7 @@
 				</g>
 				<g id="Link-:active" transform="translate(192 167)">
 					<g id="Link">
-						<text id="8:16:8:16-copy-3" fill="#2A4B8D" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="8:16:8:16-copy-3" fill="#2A4B8D" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="0" y="16">Neutral point</tspan>
 						</text>
 						<path id="Line" stroke="#2A4B8D" stroke-linecap="square" d="M1.5 18.5h57.46"/>
@@ -4272,14 +4272,14 @@
 					</g>
 				</g>
 				<g id="Link" transform="translate(192)">
-					<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="0" y="16">Neutral point</tspan>
 					</text>
 					<path id="Line" stroke="#36C" stroke-linecap="square" stroke-width="1" d="M1.5 18.5h57.46"/>
 					<path id="Line-Copy-62" stroke="#36C" stroke-linecap="square" stroke-width="1" d="M65.5 18.5h33"/>
 				</g>
 				<g id="Link" transform="translate(192 352)">
-					<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="0" y="16">Neutral point</tspan>
 					</text>
 					<path id="Line" stroke="#36C" stroke-linecap="square" stroke-width="1" d="M1.5 18.5h57.46"/>
@@ -4287,7 +4287,7 @@
 				</g>
 				<g id="Link-:hover" transform="translate(192 408)">
 					<g id="Link">
-						<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="0" y="16">Neutral point</tspan>
 						</text>
 						<path id="Line" stroke="#36C" stroke-linecap="square" d="M1.5 18.5h57.46"/>
@@ -4296,7 +4296,7 @@
 				</g>
 				<g id="Link-:active" transform="translate(192 464)">
 					<g id="Link">
-						<text id="8:16:8:16-copy-3" fill="#2A4B8D" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="8:16:8:16-copy-3" fill="#2A4B8D" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="0" y="16">Neutral point</tspan>
 						</text>
 						<path id="Line" stroke="#2A4B8D" stroke-linecap="square" d="M1.5 18.5h57.46"/>
@@ -4304,7 +4304,7 @@
 					</g>
 				</g>
 				<g id="Link" transform="translate(192 520)">
-					<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="8:16:8:16-copy-3" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="0" y="16">Neutral point</tspan>
 					</text>
 					<path id="Line" stroke="#36C" stroke-linecap="square" stroke-width="1" d="M1.5 18.5h57.46"/>
@@ -4346,7 +4346,7 @@
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(2 52)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="2" y="36">LINK</tspan>
 			</text>
 		</g>
@@ -4356,13 +4356,13 @@
 					<g id="Button-/-:disabled" transform="translate(0 .5)">
 						<rect id="bg" width="340" height="31" x=".5" y=".5" fill="#C8CCD1" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1" rx="2"/>
 					</g>
-					<text id="Other" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Other" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="270" y="23.5">Other</tspan>
 					</text>
-					<text id="Pages" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Pages" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="96" y="23.5">Pages</tspan>
 					</text>
-					<text id="All" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="All" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="27" y="23.5">All</tspan>
 					</text>
 					<path id="Path-115" stroke="#FFF" stroke-linecap="square" d="M246.5.115v33"/>
@@ -4371,65 +4371,65 @@
 				<rect id="button-frame" width="340" height="31" x="192.5" y=".5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
 				<path id="Line" stroke="#A2A9B1" stroke-linecap="square" d="M268.5.5v31"/>
 				<path id="Line-Copy-13" stroke="#A2A9B1" stroke-linecap="square" d="M438.5.5v31.015"/>
-				<text id="Talk" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Talk" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="381" y="304">Talk</tspan>
 				</text>
-				<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="220.392" y="21">All</tspan>
 				</text>
 				<rect id="Combined-Shape" width="340" height="31" x="192.5" y="112.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
 				<rect id="button-frame" width="340" height="31" x="192.5" y="224.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
 				<path id="Separator" stroke="#CCC" stroke-linecap="square" d="M268 56v32"/>
-				<text id="Pages-3-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Pages-3-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="290.296" y="21">Pages</tspan>
 				</text>
-				<text id="Other" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Other" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="463.512" y="21">Other</tspan>
 				</text>
-				<text id="Talk-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Talk-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="382.752" y="21">Talk</tspan>
 				</text>
 				<rect id="Mediawiki.Neutral.Normal-copy-14" width="340" height="31" x="192.5" y="56.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
-				<text id="All-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="All-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="220.892" y="77">All</tspan>
 				</text>
-				<text id="Pages-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Pages-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="290.296" y="77">Pages</tspan>
 				</text>
-				<text id="Other-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Other-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="463.512" y="77">Other</tspan>
 				</text>
 				<path id="Line-Copy-16" stroke="#A2A9B1" d="M268.5 56.5v31"/>
 				<path id="Separator" stroke="#A2A9B1" stroke-linecap="square" d="M268.5 111.5v32.015"/>
 				<path id="Line" stroke="#A2A9B1" stroke-linecap="square" d="M268.5 223.5v32"/>
-				<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="220.392" y="133">All</tspan>
 				</text>
-				<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="All" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="220.392" y="245">All</tspan>
 				</text>
-				<text id="Pages-8" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Pages-8" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="290.296" y="133">Pages</tspan>
 				</text>
-				<text id="Pages-8-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Pages-8-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="290.296" y="245">Pages</tspan>
 				</text>
-				<text id="Other-8" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Other-8" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="463.512" y="133">Other</tspan>
 				</text>
-				<text id="Other-8-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Other-8-Copy" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="463.512" y="245">Other</tspan>
 				</text>
 				<path id="Mediawiki.Progressive.Hover-7" fill="#FFF" stroke="#A2A9B1" d="M359.5 56.5h78v31h-78z"/>
 				<path id="Mediawiki.Progressive.Hover-8" fill="#EAECF0" stroke="#72777D" d="M359.5 112.5h78v31h-78z"/>
 				<path id="Mediawiki.Progressive.Hover-8-Copy" fill="#2A4B8D" stroke="#2A4B8D" d="M359.5 224.5h78v31h-78z"/>
-				<text id="Talk" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Talk" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="383.752" y="77">Talk</tspan>
 				</text>
-				<text id="Talk-6" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Talk-6" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="383.752" y="134">Talk</tspan>
 				</text>
-				<text id="Talk-6-Copy" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Talk-6-Copy" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="382.864" y="247">Talk</tspan>
 				</text>
 				<rect id="Mediawiki.Neutral.Normal-copy-16" width="340" height="31" x="192.5" y="168.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
@@ -4437,30 +4437,30 @@
 					<path stroke-width="2" d="M361 169h77v30h-77z"/>
 					<path d="M360.5 168.5h78v31h-78z"/>
 				</g>
-				<text id="All-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="All-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="220.392" y="189">All</tspan>
 				</text>
 				<path id="Line-Copy-21" stroke="#A2A9B1" stroke-linecap="square" d="M268.5 167.5v32.015"/>
-				<text id="Pages-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Pages-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="290.296" y="189">Pages</tspan>
 				</text>
-				<text id="Other-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Other-9" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="463.512" y="189">Other</tspan>
 				</text>
-				<text id="Talk-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Talk-7" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="383.752" y="189">Talk</tspan>
 				</text>
 				<rect id="Mediawiki.Neutral.Normal-copy-16" width="387" height="31" x="192.5" y="424.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
 				<path id="Mediawiki.Progressive.Hover-8" fill="#FFF" stroke="#A2A9B1" d="M382.5 424.5v31h92v-31h-92z"/>
 				<g id="_Spec-101-/-Headline--Sub" transform="translate(0 384)">
-					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 						<tspan x="0" y="13">ICON + TEXT</tspan>
 					</text>
 					<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
 						<path id="Line" d="M189.484 1.5H.516"/>
 					</g>
 				</g>
-				<text id="All-4" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="All-4" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="237.392" y="446">All</tspan>
 				</text>
 				<g id="Icon-/-placeholder-(notBright/circle)-/-!default" fill="#222" transform="translate(209 431)">
@@ -4475,7 +4475,7 @@
 				<g id="_Spec-101-/-16-sp-(1-em)" stroke="#D0021B" stroke-width="4" transform="translate(257 439)">
 					<path id="16-sp-(1-em)" d="M0 2h16"/>
 				</g>
-				<text id="Pages" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Pages" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="318.296" y="446">Pages</tspan>
 				</text>
 				<g id="Icon-/-placeholder-(notBright/circle)-/-!default" fill="#222" transform="translate(290 431)">
@@ -4490,7 +4490,7 @@
 				<g id="_Spec-101-/-16-sp-(1-em)" stroke="#D0021B" stroke-width="4" transform="translate(366 439)">
 					<path id="16-sp-(1-em)" d="M0 2h16"/>
 				</g>
-				<text id="Talk" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Talk" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="426.752" y="446">Talk</tspan>
 				</text>
 				<g id="Icon-/-placeholder-(notBright/circle)-/-!default" fill="#222" transform="translate(399 431)">
@@ -4505,7 +4505,7 @@
 				<g id="_Spec-101-/-16-sp-(1-em)" stroke="#D0021B" stroke-width="4" transform="translate(383 439)">
 					<path id="16-sp-(1-em)" d="M0 2h16"/>
 				</g>
-				<text id="Other" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Other" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="519.512" y="446">Other</tspan>
 				</text>
 				<g id="Icon-/-placeholder-(notBright/circle)-/-!default" fill="#222" transform="translate(491 431)">
@@ -4549,7 +4549,7 @@
 						<path stroke="#FFF" d="M6.448 11.787l2.721 6.886c.273.675-.094 1.44-.79 1.72-.696.283-1.491-.013-1.765-.692l-2.708-6.853-2.483 2.963-.077.075c-.901.695-1.848.236-1.846-.902L-.474.669c0-.618.027-.82.271-1.028.4-.34.694-.163 1.14.298l10.66 10.157c.793.817.432 1.805-.782 1.933l-4.367-.242z"/>
 					</g>
 				</g>
-				<g id="State-labels" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal" transform="translate(0 8)">
+				<g id="State-labels" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal" transform="translate(0 8)">
 					<text id="Disabled">
 						<tspan x="0" y="295">Disabled</tspan>
 					</text>
@@ -4577,7 +4577,7 @@
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 95)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="0" y="36">BUTTON </tspan> <tspan x="0" y="80">GROUP</tspan>
 			</text>
 		</g>
@@ -4585,14 +4585,14 @@
 			<g id="Quiet-Buttons-X" transform="translate(0 113)">
 				<g id="Icon-+-Text" transform="translate(612 304)">
 					<circle id="Oval-54" cx="218" cy="55" r="10" fill="#222"/>
-					<text id="Button" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Button" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="235.36" y="60">Button</tspan>
 					</text>
 					<path id="Line-183" stroke="#50E3C2" stroke-width="4" d="M228 55h8"/>
 					<path id="Line-178-Copy" stroke="#D0021B" stroke-width="4" d="M192 55h16"/>
 					<path id="Line-179-Copy" stroke="#D0021B" stroke-width="4" d="M286 55h16"/>
 					<g id="_Spec-101-/-Headline--Sub">
-						<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+						<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 							<tspan x="0" y="13">ICON + TEXT</tspan>
 						</text>
 						<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -4606,7 +4606,7 @@
 						<rect width="121" height="30" x="203" y="169" stroke="#36C" stroke-width="2" rx="2"/>
 						<rect width="122" height="31" x="202.5" y="168.5" stroke="#36C" rx="2"/>
 					</g>
-					<text id="Label" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="218.452" y="190">Progressive</tspan>
 					</text>
 					<g id="BG">
@@ -4614,7 +4614,7 @@
 						<rect width="119" height="31" x="366.5" y="168.5" stroke="#D33" stroke-linejoin="square" rx="2"/>
 						<rect width="121" height="33" x="365.5" y="167.5" stroke="#D33" rx="2"/>
 					</g>
-					<text id="Label" fill="#D33" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#D33" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="381.288" y="190">Destructive</tspan>
 					</text>
 					<rect id="BG" width="122" height="31" x="202.5" y="112.5" fill="#2A4B8D" stroke="#2A4B8D" rx="2"/>
@@ -4628,47 +4628,47 @@
 						<use xlink:href="#text-196"/>
 					</g>
 					<rect id="BG" width="122" height="31" x="202.5" y="56.5" fill="#347BFF" stroke="#347BFF" opacity=".2" rx="2"/>
-					<text id="Label" fill="#347BFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#347BFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="218.452" y="78">Progressive</tspan>
 					</text>
 					<rect id="BG" width="120" height="32" x="365" y="56" fill="#D11D13" opacity=".2" rx="2"/>
-					<text id="Label" fill="#D33" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#D33" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="381" y="79">Destructive</tspan>
 					</text>
-					<text id="Label" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#36C" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="218.452" y="22">Progressive</tspan>
 					</text>
-					<text id="Label" fill="#D33" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#D33" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="381.288" y="22">Destructive</tspan>
 					</text>
-					<text id="Label" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="218" y="246">Progressive</tspan>
 					</text>
-					<text id="Label" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="381" y="246">Destructive</tspan>
 					</text>
-					<text id="Label" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#72777D" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="30" y="246">Neutral</tspan>
 					</text>
 					<g id="_Spec-101-/-16-sp-(1-em)" stroke="#D0021B" stroke-width="4" transform="translate(86 239)">
 						<path id="16-sp-(1-em)" d="M0 2h16"/>
 					</g>
-					<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="30.152" y="22">Neutral</tspan>
 					</text>
 					<rect id="BG" width="88" height="32" x="14" y="56" fill="#F8F9FA" rx="2"/>
-					<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="30.152" y="78">Neutral</tspan>
 					</text>
 					<rect id="BG" width="87" height="31" x="14.5" y="112.5" fill="#EAECF0" stroke="#72777D" rx="2"/>
-					<text id="Label" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="29" y="133">Neutral</tspan>
 					</text>
 					<g id="BG" stroke="#36C" stroke-linejoin="square">
 						<rect width="86" height="30" x="15" y="169" stroke-width="2" rx="2"/>
 						<rect width="87" height="31" x="14.5" y="168.5" rx="2"/>
 					</g>
-					<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="30.152" y="190">Neutral</tspan>
 					</text>
 					<g id="_Spec-101-/-16-sp-(1-em)-+-2-*-8-sp-(0.5-em)" stroke-width="4" transform="rotate(-90 16 16)">
@@ -4709,7 +4709,7 @@
 					</g>
 				</g>
 				<g id="Icon" transform="translate(0 341)">
-					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="612" y="129.2">Normal</tspan> <tspan x="612" y="185.3">Hover</tspan> <tspan x="612" y="241.4">Active</tspan> <tspan x="612" y="297.5">Focus</tspan> <tspan x="612" y="353.6">Disabled</tspan>
 					</text>
 					<rect id="Rectangle-640-Copy-14" width="36" height="32" x="873" y="167" fill="#F8F9FA" rx="2" transform="matrix(1 0 0 -1 0 366)"/>
@@ -4722,10 +4722,10 @@
 					<path id="Line-Copy-60" fill="#C70070" fill-rule="nonzero" d="M903.49 172.422l.018 1-4 .069.332 18.997 4-.07.017 1-4 .07-.48.008-4.519.08-.017-1 3.999-.071-.332-18.997-3.999.07-.017-1 4-.07.479-.008 4.52-.078z"/>
 					<path id="Line-Copy-61" fill="#C70070" fill-rule="nonzero" d="M905.49 166.422l.018 1-4 .069.542 30.995 4-.07.017 1-4 .07-.52.009-4.48.079-.017-1 4-.071-.542-30.995-3.999.07-.017-1 4-.07.479-.008 4.52-.078z"/>
 					<rect id="Rectangle-639-Copy-2" width="20" height="20" x="867" y="173" fill="#222" rx="10"/>
-					<text id="20-sp-x-20-sp-icon-`" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+					<text id="20-sp-x-20-sp-icon-`" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 						<tspan x="912" y="180">20 sp x 20 sp icon</tspan> <tspan x="912" y="195">`vertical align: middle`</tspan>
 					</text>
-					<text id="36-sp-minimum-width" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+					<text id="36-sp-minimum-width" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 						<tspan x="912" y="131">36 sp minimum width touch target</tspan>
 					</text>
 					<path id="Shape-Copy-3" fill="#7D8389" d="M823.5 349c.625 0 1.25.25 1.75.75s.75 1 .75 1.75c0 .625-.25 1.25-.75 1.75s-1.125.75-1.75.75-1.25-.25-1.75-.75-.75-1.125-.75-1.75.25-1.25.75-1.75 1-.75 1.75-.75zm7.5 0c.625 0 1.25.25 1.75.75s.75 1 .75 1.75c0 .625-.25 1.25-.75 1.75s-1.125.75-1.75.75-1.25-.25-1.75-.75-.75-1.125-.75-1.75.25-1.25.75-1.75 1-.75 1.75-.75zm7.5 0c.625 0 1.25.25 1.75.75s.75 1 .75 1.75c0 .625-.25 1.25-.75 1.75s-1.125.75-1.75.75-1.25-.25-1.75-.75-.75-1.125-.75-1.75.25-1.25.75-1.75 1-.75 1.75-.75z" transform="matrix(1 0 0 -1 0 703)"/>
@@ -4763,7 +4763,7 @@
 						<path id="Shape-Copy-6" d="M4.25.75C3.75.25 3.125 0 2.5 0 1.75 0 1.25.25.75.75S0 1.875 0 2.5s.25 1.25.75 1.75S1.875 5 2.5 5s1.25-.25 1.75-.75S5 3.125 5 2.5c0-.75-.25-1.25-.75-1.75z" transform="matrix(1 0 0 -1 0 5)"/>
 					</g>
 					<g id="_Spec-101-/-Headline--Sub" transform="translate(612 71)">
-						<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+						<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 							<tspan x="0" y="13">ICON</tspan>
 						</text>
 						<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -4789,14 +4789,14 @@
 						<path stroke="#FFF" d="M6.448 11.787l2.721 6.886c.273.675-.094 1.44-.79 1.72-.696.283-1.491-.013-1.765-.692l-2.708-6.853-2.483 2.963-.077.075c-.901.695-1.848.236-1.846-.902L-.474.669c0-.618.027-.82.271-1.028.4-.34.694-.163 1.14.298l10.66 10.157c.793.817.432 1.805-.782 1.933l-4.367-.242z"/>
 					</g>
 				</g>
-				<text id="State-Description" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="State-Description" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="612" y="21.1">Normal</tspan> <tspan x="612" y="77.2">Hover</tspan> <tspan x="612" y="133.3">Active</tspan> <tspan x="612" y="189.4">Focus</tspan> <tspan x="612" y="245.5">Disabled</tspan>
 				</text>
 			</g>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(612 95)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text id="BUTTONS-QUIET" fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text id="BUTTONS-QUIET" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="612" y="36">BUTTONS</tspan> <tspan x="612" y="80">QUIET</tspan>
 			</text>
 		</g>
@@ -4804,18 +4804,18 @@
 			<g id="Normal-&amp;-Primary-Buttons-X" transform="translate(1 113)">
 				<g id="Button-toggle-/-!default" transform="translate(192 464)">
 					<rect id="bg" width="107" height="31" x=".5" y=".5" fill="#F8F9FA" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
-					<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="17.48" y="22">Toggle off</tspan>
 					</text>
 				</g>
 				<g id="Button-toggle-/-:selected" transform="translate(381 464)">
 					<rect id="bg" width="107" height="31" x=".5" y=".5" fill="#2A4B8D" fill-rule="evenodd" stroke="#2A4B8D" stroke-width="1" rx="2"/>
-					<text id="label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+					<text id="label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 						<tspan x="16.436" y="22">Toggle on</tspan>
 					</text>
 				</g>
 				<g id="_Spec-101-/-Headline--Sub" transform="translate(0 424)">
-					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 						<tspan x="0" y="13">TOGGLE BUTTON</tspan>
 					</text>
 					<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -4823,7 +4823,7 @@
 					</g>
 				</g>
 				<g id="_Spec-101-/-Headline--Sub" transform="translate(0 304)">
-					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+					<text id="SUBHEADLINE" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 						<tspan x="0" y="13">ICON + TEXT</tspan>
 					</text>
 					<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(0 22)">
@@ -4831,11 +4831,11 @@
 					</g>
 				</g>
 				<rect id="Mediawiki.Neutral.Normal-copy-2" width="112" height="31" x="192.5" y="344.5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
-				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="0" y="21">Normal</tspan> <tspan x="0" y="77.1">Hover</tspan> <tspan x="0" y="133.2">Active</tspan> <tspan x="0" y="189.3">Focus</tspan> <tspan x="0" y="245.4">Disabled</tspan>
 				</text>
 				<path id="Oval-59" fill="#222" d="M218 370c5.523 0 10-4.477 10-10s-4.477-10-10-10-10 4.477-10 10 4.477 10 10 10z"/>
-				<text id="Button" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Button" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="237" y="367">Button</tspan>
 				</text>
 				<g id="_Spec-101-/-16-sp-(1-em)-+-2-*-8-sp-(0.5-em)" stroke-width="4" transform="rotate(90 -21 203)">
@@ -4857,7 +4857,7 @@
 					<rect width="124" height="33" x="379.5" y="167.5" stroke="#36C" rx="2"/>
 					<rect width="122" height="31" x="380.5" y="168.5" stroke="#36C" stroke-linejoin="square" rx="2"/>
 				</g>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="396.452" y="189">Progressive</tspan>
 				</text>
 				<g id="BG">
@@ -4865,39 +4865,39 @@
 					<rect width="119" height="31" x="543.5" y="168.5" stroke="#D11D13" stroke-linejoin="square" rx="2"/>
 					<rect width="121" height="33" x="542.5" y="167.5" stroke="#D11D13" rx="2"/>
 				</g>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="559.288" y="190">Destructive</tspan>
 				</text>
 				<rect id="BG" width="122" height="31" x="380.5" y="112.5" fill="#2A4B8D" stroke="#2A4B8D" rx="2"/>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="396.452" y="134">Progressive</tspan>
 				</text>
 				<rect id="BG" width="119" height="31" x="543.5" y="112.5" fill="#951B19" stroke="#951B19" rx="2"/>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="559.288" y="134">Destructive</tspan>
 				</text>
 				<rect id="BG" width="122" height="31" x="380.5" y="56.5" fill="#447FF5" stroke="#447FF5" rx="2"/>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="396.452" y="78">Progressive</tspan>
 				</text>
 				<rect id="BG" width="119" height="31" x="543.5" y="56.5" fill="#B8211F" stroke="#B8211F" rx="2"/>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="559.288" y="78">Destructive</tspan>
 				</text>
 				<rect id="BG" width="122" height="31" x="380.5" y=".5" fill="#36C" stroke="#36C" rx="2"/>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="396.452" y="22">Progressive</tspan>
 				</text>
 				<rect id="BG" width="120" height="32" x="543" y="0" fill="#D33" rx="2"/>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="559.288" y="22">Destructive</tspan>
 				</text>
 				<rect id="BG" width="122" height="31" x="380.5" y="224.5" fill="#C8CCD1" stroke="#C8CCD1" rx="2"/>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="396" y="247">Progressive</tspan>
 				</text>
 				<rect id="BG" width="119" height="31" x="543.5" y="224.5" fill="#C8CCD1" stroke="#C8CCD1" rx="2"/>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="559" y="246">Destructive</tspan>
 				</text>
 				<rect id="BG" width="87" height="31" x="192.5" y="224.5" fill="#C8CCD1" stroke="#C8CCD1" rx="2"/>
@@ -4908,34 +4908,34 @@
 				<path id="Line-234" stroke="#D0021B" stroke-width="4" d="M289 360h16"/>
 				<rect id="Mediawiki.Neutral.Normal-copy-3" width="112" height="31" x="381.5" y="344.5" fill="#36C" stroke="#36C" rx="2"/>
 				<circle id="Oval-77" cx="408" cy="360" r="10" fill="#FFF"/>
-				<text id="Button-6" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Button-6" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="426.36" y="366">Button</tspan>
 				</text>
 				<rect id="Mediawiki.Neutral.Normal-copy-6" width="112" height="31" x="543.5" y="344.5" fill="#D11D13" stroke="#D11D13" rx="2"/>
 				<circle id="Oval-82" cx="570" cy="360" r="10" fill="#FFF"/>
-				<text id="Button-8" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Button-8" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="588.36" y="366">Button</tspan>
 				</text>
-				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="208" y="246">Neutral</tspan>
 				</text>
 				<rect id="BG" width="87" height="31" x="192.5" y=".5" fill="#F8F9FA" stroke="#A2A9B1" rx="2"/>
-				<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="208" y="21">Neutral</tspan>
 				</text>
 				<rect id="BG" width="87" height="31" x="192.5" y="56.5" fill="#FFF" stroke="#A2A9B1" rx="2"/>
-				<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="208" y="78">Neutral</tspan>
 				</text>
 				<rect id="BG" width="87" height="31" x="192.5" y="112.5" fill="#EAECF0" stroke="#72777D" rx="2"/>
-				<text id="Label" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="208" y="134">Neutral</tspan>
 				</text>
 				<g id="BG" stroke="#36C" stroke-linejoin="square">
 					<rect width="86" height="30" x="193" y="169" stroke-width="2" rx="2"/>
 					<rect width="87" height="31" x="192.5" y="168.5" rx="2"/>
 				</g>
-				<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+				<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 					<tspan x="208.152" y="190">Neutral</tspan>
 				</text>
 				<g id="Cursor-/-Pointer" transform="translate(259 130)">
@@ -4963,15 +4963,15 @@
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(1 95)">
 				<path id="Line" d="M183.5 1.5H.5"/>
 			</g>
-			<text id="BUTTONS-NORMAL-+-PRI" fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text id="BUTTONS-NORMAL-+-PRI" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="1" y="36">BUTTONS </tspan> <tspan x="1" y="80">NORMAL + PRIMARY </tspan>
 			</text>
 		</g>
 		<g id="SPECIFICATIONS" transform="translate(-309 185)">
-			<text fill="#222" font-family="Lato-Bold, Lato" font-size="36" font-weight="bold">
+			<text fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="36" font-weight="bold">
 				<tspan x="469" y="36">SPECIFICATIONS</tspan>
 			</text>
-			<text id="SPECIFICATIONS-LEGEN" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+			<text id="SPECIFICATIONS-LEGEN" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 				<tspan x="471" y="90">SPECIFICATIONS</tspan> <tspan x="472.206" y="128.199" font-size="12">LEGEND</tspan> <tspan x="479.442" y="382.393" font-size="12">MAIN TOOLBAR</tspan> <tspan x="479.442" y="398.393" font-size="12">48PX HEIGHT</tspan> <tspan x="479.442" y="695.393" font-size="12">SECONDARY TOOLBAR</tspan> <tspan x="479.442" y="712.393" font-size="12">30PX HEIGHT</tspan>
 			</text>
 			<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3" transform="translate(469 53)">
@@ -5049,7 +5049,7 @@
 			<path id="Line-95" stroke="#50E3C2" stroke-linecap="square" d="M824.5 690.462h-8"/>
 			<path id="Line-94" stroke="#50E3C2" stroke-linecap="square" d="M777.5 690.462h-8"/>
 			<g id="Specifications-(right-col)" transform="translate(1283 54)">
-				<text id="SPECIFICATIONS" fill="#222" font-family="Lato-Bold, Lato" font-size="14" font-weight="bold">
+				<text id="SPECIFICATIONS" fill="#222" font-family="Lato-Bold, Lato, sans-serif" font-size="14" font-weight="bold">
 					<tspan x="0" y="38">SPECIFICATIONS</tspan> <tspan x="1.206" y="76.199" font-size="12">LEGEND</tspan> <tspan x="1.206" y="328.199" font-size="12">TEXT</tspan> <tspan x="1.206" y="388.199" font-size="12">ICON</tspan> <tspan x="1.206" y="448.199" font-size="12">ICON-TEXT</tspan> <tspan x="1.206" y="544.199" font-size="12">INLINE ICON</tspan> <tspan x="1.206" y="604.199" font-size="12">INLINE ICON + </tspan> <tspan x="8.442" y="620.393" font-size="12">ICON-TEXT</tspan> <tspan x="1.206" y="667.199" font-size="12">INLINE TEXT</tspan>
 				</text>
 				<g id="_Spec-101-/-Headline__line" stroke="#EAECF0" stroke-linecap="square" stroke-width="3">
@@ -5101,34 +5101,34 @@
 				<rect id="Rectangle-302" width="14" height="18" x="254" y="196" fill="#C70070" rx="1"/>
 				<rect id="Rectangle-303" width="42" height="18" x="256" y="426" fill="#C70070" rx="1"/>
 				<rect id="Rectangle-303" width="42" height="18" x="338" y="591" fill="#C70070" rx="1"/>
-				<text id="Text" fill="#222" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="Text" fill="#222" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="271" y="233">Text</tspan>
 				</text>
-				<text id="Icon" fill="#222" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="Icon" fill="#222" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="374" y="233">Icon</tspan>
 				</text>
-				<text id="Button-frame" fill="#222" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="Button-frame" fill="#222" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="451" y="233">Button frame</tspan>
 				</text>
 				<path id="Line-51" stroke="#D0021B" stroke-linecap="square" d="M233.5 376.462h-12M236.5 320.462h-12"/>
-				<text id="16-sp-/-1-em" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="16-sp-/-1-em" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="551" y="77">16 sp / 1 em</tspan>
 				</text>
 				<path id="Line-53" stroke="#D0021B" stroke-linecap="square" d="M265.5 376.462h-12M263.5 320.462h-12"/>
 				<path id="Line-49" stroke="#50E3C2" stroke-linecap="square" d="M244.5 361.5v3.986M244.5 306.5v3.986"/>
-				<text id="8-sp-/-0.5-em" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="8-sp-/-0.5-em" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="551" y="101">8 sp / 0.5 em</tspan>
 				</text>
-				<text id="4-sp-/-0.25-em" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="4-sp-/-0.25-em" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="551" y="125">4 sp / 0.25 em</tspan>
 				</text>
-				<text id="24-sp-/-1.5-em" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="24-sp-/-1.5-em" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="551" y="53">24 sp / 1.5 em</tspan>
 				</text>
-				<text id="32-scale-independent" fill="#C70070" font-family="Lato-Regular, Lato" font-size="12" font-weight="normal">
+				<text id="32-scale-independent" fill="#C70070" font-family="Lato-Regular, Lato, sans-serif" font-size="12" font-weight="normal">
 					<tspan x="551" y="31">32 scale-independent pixels / 2 em</tspan>
 				</text>
-				<text id="All-single-buttons," fill="#54595D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+				<text id="All-single-buttons," fill="#54595D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 					<tspan x="227" y="33">All single buttons, icons, text </tspan> <tspan x="227" y="51">field have a min. of 40 scale-</tspan> <tspan x="227" y="69">independent pixels (sp) width.</tspan> <tspan x="227" y="105">All single buttons have a max. of </tspan> <tspan x="227" y="123">280 sp width. If &gt;280 sp text </tspan> <tspan x="227" y="141">wraps to the next line.</tspan>
 				</text>
 				<path id="Line-50" stroke="#50E3C2" stroke-linecap="square" d="M244.5 386.5v3.986M244.5 329.5v3.986"/>


### PR DESCRIPTION
Add `sans-serif` as font fallback to components overview and components
SVGs as Sketch doesn't provide such option in it's export settings.