### PR TITLE
Unnecessary ampersand removed

### DIFF
--- a/components/text-inputs-and-textarea.html
+++ b/components/text-inputs-and-textarea.html
@@ -109,7 +109,7 @@
 							Indicator icons are used in two contexts with inputs:
 						</p>
 						<ul>
-							<li>Showing that a user input is required with a 'required'&<img class="icon icon--indicator" src="../resources/WikimediaUI-icons-SVGs/required.svg" alt="required indicator"> indicator</li>
+							<li>Showing that a user input is required with a 'required' <img class="icon icon--indicator" src="../resources/WikimediaUI-icons-SVGs/required.svg" alt="required indicator"> indicator</li>
 							<li>Clearing the input, like in search inputs with a 'clear' <img class="icon icon--indicator" src="../resources/WikimediaUI-icons-SVGs/clear.svg" alt="clear indicator"> indicator</li>
 						</ul>
 						<p>The <strong>length</strong> (width and number of lines) provides a hint to users as to the expected length of their input. Textareas should be used when the input length is multiple sentences long, whereas shorter responses like a search query or password have to be limited to a single line.</p>


### PR DESCRIPTION
"Text inputs and textarea" section had an "&" character by mistake. This change removes the unnecessary character.