### PR TITLE
Remove IRC link

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,8 +73,7 @@
 						<p>We encourage and welcome your collaboration and participation to evolve the Wikimedia Design Style Guide. <br>You can engage in many ways:</p>
 						<ul>
 							<li><strong>Contribute</strong><br>Read <a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/blob/master/CONTRIBUTING.md" target="_blank" rel="noopener">contributing guidelines on GitHub</a> and make a pull request.</li>
-							<li><strong>Request a change or an addition</strong><br><a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=wikimedia_design_style_guide" target="_blank" rel="noopener" property="discussionUrl">File a task on our workboard</a> to request a change to the style guide.</li>
-							<li><strong>Provide feedback</strong><br>Get in touch with us on <a href="https://meta.wikimedia.org/wiki/IRC/Channels#wikimedia-design" target="_blank" rel="noopener">IRC</a>.</li>
+							<li><strong>Request a change or provide feedback</strong><br><a href="https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?projects=wikimedia_design_style_guide" target="_blank" rel="noopener" property="discussionUrl">File a task on our workboard</a> to request a change to the style guide.</li>
 							<li><strong>Follow Wikimedia Design Team</strong><br>Follow <a href="https://twitter.com/WikimediaUX" target="_blank" rel="noopener">@WikimediaUX on Twitter</a>.</li>
 							<li><strong>Play around</strong><br><a href="https://github.com/wikimedia/WikimediaUI-Style-Guide/archive/master.zip" target="_blank" rel="noopener">Download Wikimedia Design Style Guide</a>.</li>
 						</ul>


### PR DESCRIPTION
It isn't the best place to get in contact with the design team
compared to the other points of contact.

Decision made in today's Style Guide meeting.