### PR TITLE
“Components – File inputs”: Add resources links to file naming guidelines

### DIFF
--- a/components/file-inputs.html
+++ b/components/file-inputs.html
@@ -110,7 +110,16 @@
 					</section>
 					<section id="coding">
 						<h2>Coding</h2>
-					<p>See <a href="https://doc.wikimedia.org/oojs-ui/master/demos/?page=widgets&theme=wikimediaui&direction=ltr&platform=desktop#SelectFileInputWidget" target="_blank" rel="noopener">OOUI's demos section of file inputs</a>.</p>
+						<p>See <a href="https://doc.wikimedia.org/oojs-ui/master/demos/?page=widgets&theme=wikimediaui&direction=ltr&platform=desktop#SelectFileInputWidget" target="_blank" rel="noopener">OOUI's demos section of file inputs</a>.</p>
+					</section>
+					<section id="resources">
+						<h2>Resources</h2>
+						<p>Several Wikimedia projects provide file naming guidelines, that might be of interest for file input hints. <br>A selection:</p>
+						<ul>
+							<li><a href="https://commons.wikimedia.org/wiki/Commons:File_naming" target="_blank" rel="noopener">Wikimedia Commons file naming proposal</a></li>
+							<li><a href="https://en.wikipedia.org/wiki/Wikipedia:File_names" target="_blank" rel="noopener">English Wikipedia file naming convention</a></li>
+						</ul>
+					</section>
 				</main>
 			</div>
 		</div>


### PR DESCRIPTION
Adding resource hints to exemplary file naming guidelines of Wikimedia projects.