### PR TITLE
“Components”: Ensure SVG font choice is accurately rendered

### DIFF
--- a/img/components/buttons_toggle_intro.svg
+++ b/img/components/buttons_toggle_intro.svg
@@ -24,13 +24,13 @@
 									<path id="Rectangle-1" d="M0 0h20v20H0z"/>
 								</g>
 							</g>
-							<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="38" y="22">Toggle</tspan>
 							</text>
 						</g>
 						<g id="Button-toggle-/-:selected" transform="translate(192 56)">
 							<rect id="bg" width="100" height="31" x=".5" y=".5" fill="#2A4B8D" fill-rule="evenodd" stroke="#2A4B8D" stroke-width="1" rx="2"/>
-							<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="38" y="22">Toggle</tspan>
 							</text>
 							<g id="🔣-Icon/Moderation/pushPin" transform="translate(12 6)">
@@ -43,7 +43,7 @@
 								</g>
 							</g>
 						</g>
-						<text id="Normal-Selected" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+						<text id="Normal-Selected" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 							<tspan x="0" y="21">Normal</tspan> <tspan x="0" y="77.1">Selected</tspan>
 						</text>
 					</g>

--- a/img/components/checkboxes_indeterminate_intro_on.svg
+++ b/img/components/checkboxes_indeterminate_intro_on.svg
@@ -12,7 +12,7 @@
 			<g id="CHECKBOX-DESKTOP" transform="translate(5038 186)">
 				<g id="Checkbox-indeterminate" transform="translate(2 787)">
 					<g id="Checkbox-/-:indeterminate:checked-/-!default" transform="translate(480 41)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="23">Indeterminate – some children selected</tspan>
 						</text>
 						<g id="Checkbox" fill-rule="evenodd" stroke-width="1" transform="translate(0 5)">
@@ -29,13 +29,13 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-!default" transform="translate(512 78)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Unselected</tspan>
 						</text>
 						<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>
 					</g>
 					<g id="Checkbox-/-:checked-/-!default" transform="translate(512 117)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="23">Selected</tspan>
 						</text>
 						<g id="Checkbox" fill-rule="evenodd" stroke-width="1" transform="translate(0 5)">
@@ -46,7 +46,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-!default" transform="translate(192 43)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>

--- a/img/components/checkboxes_states.svg
+++ b/img/components/checkboxes_states.svg
@@ -114,10 +114,10 @@
 			<path fill="#FFF" d="M0 0h14720v3264H0z"/>
 			<g id="CHECKBOX-DESKTOP" transform="translate(5038 186)">
 				<g id="Checkbox-X" transform="translate(2 69)">
-					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="0" y="22.1">Normal</tspan> <tspan x="0" y="78.2">Hover</tspan> <tspan x="0" y="134.3">Active</tspan> <tspan x="0" y="190.4">Focus</tspan> <tspan x="0" y="246.5">Disabled</tspan>
 					</text>
-					<text id="Selected" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Selected" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="479" y="304">Selected</tspan>
 					</text>
 					<g id="_Spec-/-16-sp-(1-em)-+-2-*-4-sp-(0.25-em)" stroke-width="4" transform="rotate(-90 216 38)">
@@ -132,7 +132,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:checked-/-:disabled" transform="translate(480 226)">
-						<text id="Label" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<g id="Mediawiki.Neutral.Hover-copy-10-+-Imported-Layers-Copy-2" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -143,7 +143,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:checked-/-:hover" transform="translate(480 57)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<g id="Mediawiki.Neutral.Hover-copy-12-+-Imported-Layers-Copy-3" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -154,7 +154,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:checked-/-:active" transform="translate(480 113)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<g id="checkbox:checked:active" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -165,7 +165,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:checked-/-:focus" transform="translate(480 169)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<g id="checkbox:checked:focus" fill-rule="evenodd" stroke-width="1" transform="translate(0 4)">
@@ -180,7 +180,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:checked-/-!default" transform="translate(480)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="23">Neutral point</tspan>
 						</text>
 						<g id="Checkbox" fill-rule="evenodd" stroke-width="1" transform="translate(0 5)">
@@ -191,25 +191,25 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-:disabled" transform="translate(192 226)">
-						<text id="Label" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#7D8389" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<path id="checkbox" fill="#C8CCD1" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1" d="M2.005 4.5C1.174 4.5.5 5.173.5 6.005v19.99c0 .831.673 1.505 1.505 1.505h19.99c.831 0 1.505-.673 1.505-1.505V6.005c0-.831-.673-1.505-1.505-1.505H2.005z"/>
 					</g>
 					<g id="Checkbox-/-:active" transform="translate(192 113)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#2A4B8D" fill-rule="evenodd" stroke="#2A4B8D" stroke-width="1" rx="2"/>
 					</g>
 					<g id="Checkbox-/-:hover" transform="translate(192 57)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<rect id="checkbox" width="23" height="23" x=".5" y="4.5" stroke="#2962CC" stroke-width="1" rx="2"/>
 					</g>
 					<g id="Checkbox-/-:focus" transform="translate(192 169)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<g id="checkbox" stroke="#36C" stroke-linejoin="square">
@@ -218,7 +218,7 @@
 						</g>
 					</g>
 					<g id="Checkbox-/-!default" transform="translate(192 1)">
-						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="32" y="22">Neutral point</tspan>
 						</text>
 						<rect id="checkbox" width="23" height="23" x=".5" y="4.5" fill="#FFF" fill-rule="evenodd" stroke="#72777D" stroke-width="1" rx="2"/>

--- a/img/components/dropdowns_designing.svg
+++ b/img/components/dropdowns_designing.svg
@@ -32,7 +32,7 @@
 								<rect width="271" height="31" x=".5" y=".5" fill="#FFF" stroke="#36C" stroke-linejoin="square" rx="2"/>
 								<rect width="273" height="33" x="-.5" y="-.5" stroke="#36C" rx="2"/>
 							</g>
-							<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="12" y="22">Item 1 selected </tspan>
 							</text>
 							<g id="🔣-Icon/Indicators/down" transform="translate(247.867 11)">
@@ -51,14 +51,14 @@
 						</g>
 						<path id="Bg-menu-option:hover" fill="#EBF2FF" fill-rule="evenodd" d="M1 33h269.993v31.007a.991.991 0 01-1.005.993H2.005A1.004 1.004 0 011 64.007V33z"/>
 						<path id="Bg-menu-option:hover" fill="#FFF" fill-rule="evenodd" d="M1 65h269.993v31.007a.991.991 0 01-1.005.993H2.005A1.004 1.004 0 011 96.007V65z"/>
-						<text id="Menu-option" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Menu-option" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="13" y="87">Item 2</tspan>
 						</text>
-						<text id="Menu-option" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Menu-option" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="13" y="55">Item 1</tspan>
 						</text>
 					</g>
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal" transform="translate(193 350)">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal" transform="translate(193 350)">
 						<tspan x="0" y="15">Label</tspan>
 					</text>
 					<g id="_Spec-/-12-sp-(0.75-em)" stroke="#0082FF" stroke-width="4" transform="translate(453 390.5)">

--- a/img/components/dropdowns_states.svg
+++ b/img/components/dropdowns_states.svg
@@ -90,7 +90,7 @@
 					<g id="Dropdown-/-:hover" transform="translate(192 56)">
 						<g id="Dropdown-/-!default">
 							<rect id="Dropdown" width="271" height="31" x=".5" y=".5" fill="#FFF" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
-							<text id="Label" fill="#444" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="Label" fill="#444" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="12.148" y="23">Select an item</tspan>
 							</text>
 							<g id="🔣-Icon/Indicators/down" transform="translate(245.6 11)">
@@ -111,7 +111,7 @@
 								<rect width="271" height="31" x=".5" y=".5" fill="#FFF" stroke="#36C" stroke-linejoin="square" rx="2"/>
 								<rect width="273" height="33" x="-.5" y="-.5" stroke="#36C" rx="2"/>
 							</g>
-							<text id="Label" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="Label" fill="#000" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="12.148" y="23">Select an item</tspan>
 							</text>
 							<g id="🔣-Icon/Indicators/down" transform="translate(245.6 11)">
@@ -144,7 +144,7 @@
 								<rect width="273" height="31" x=".5" y=".5" fill="#FFF" stroke="#36C" stroke-linejoin="square" rx="2"/>
 								<rect width="275" height="33" x="-.5" y="-.5" stroke="#36C" rx="2"/>
 							</g>
-							<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="12" y="22">Item 1 selected </tspan>
 							</text>
 							<g id="🔣-Icon/Indicators/down" transform="translate(249.733 11)">
@@ -163,17 +163,17 @@
 						</g>
 						<path id="Bg-menu-option:hover" fill="#EBF2FF" fill-rule="evenodd" d="M1 33h271.985v31.007a.992.992 0 01-.998.993H1.998A1 1 0 011 64.007V33z"/>
 						<path id="Bg-menu-option:hover" fill="#EAECF0" fill-rule="evenodd" d="M1 65h271.985v31.007a.992.992 0 01-.998.993H1.998A1 1 0 011 96.007V65z"/>
-						<text id="Menu-option" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Menu-option" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="13" y="87">Item 2</tspan>
 						</text>
-						<text id="Menu-option" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+						<text id="Menu-option" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 							<tspan x="13" y="55">Item 1</tspan>
 						</text>
 					</g>
 					<g id="Dropdown-/-:disabled" transform="translate(192 296)">
 						<g id="Dropdown-/-!default">
 							<rect id="Dropdown" width="271" height="31" x=".5" y=".5" fill="#C8CCD1" fill-rule="evenodd" stroke="#C8CCD1" stroke-width="1" rx="2"/>
-							<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="Label" fill="#FFF" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="12" y="23">Select an item</tspan>
 							</text>
 							<g id="🔣-Icon/Indicators/down" transform="translate(245.6 11)">
@@ -189,7 +189,7 @@
 					</g>
 					<g id="Dropdown-/-!default" transform="translate(192)">
 						<rect id="Dropdown" width="271" height="31" x=".5" y=".5" fill="#F8F9FA" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
-						<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="12" y="22">Select an item</tspan>
 						</text>
 						<g id="🔣-Icon/Indicators/down" transform="translate(245.6 11)">
@@ -208,7 +208,7 @@
 							<path fill="#FFF" stroke="#000" d="M5.499 15V1.424C5.499.365 6.346-.5 7.396-.5c1.052 0 1.91.865 1.91 1.925v7.172a2.116 2.116 0 011.087-.298c.977 0 1.809.653 2.044 1.54.332-.216.73-.341 1.16-.341.926 0 1.716.584 1.996 1.399a1.7 1.7 0 01.805-.201 1.69 1.69 0 011.697 1.683v-.002l.006 1.586v3.239c0 .257-.022.519-.066.787-.155.942-.512 1.811-1.212 3.158-1.01 1.946-1.165 2.297-1.165 2.853v.5h-8.99V24c0-.421-.472-1.169-1.853-3.03l-.079-.106a34.473 34.473 0 01-1.02-1.43c-.39-.583-.991-1.5-1.748-2.664l-.027-.043a1115.225 1115.225 0 01-2.009-3.1l-.199-.309c-.49-.83-.181-1.897.675-2.38.85-.48 1.932-.212 2.383.56L5.5 15z"/>
 						</g>
 					</g>
-					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato" font-size="14" font-weight="normal">
+					<text id="Normal-Hover-Active" fill="#72777D" font-family="Lato-Regular, Lato, sans-serif" font-size="14" font-weight="normal">
 						<tspan x="0" y="19">Normal</tspan> <tspan x="0" y="75.1">Hover</tspan> <tspan x="0" y="131.2">Active &amp; </tspan> <tspan x="0" y="149.9">Focus</tspan> <tspan x="0" y="187.3">Expanded Menu &amp;</tspan> <tspan x="0" y="206">Focus</tspan> <tspan x="0" y="318.2">Disabled</tspan>
 					</text>
 				</g>

--- a/img/components/file_inputs_designing.svg
+++ b/img/components/file_inputs_designing.svg
@@ -17,7 +17,7 @@
 						</g>
 						<g id="Button-/-!default-(--neutral)" transform="translate(287)">
 							<rect id="bg" width="112" height="31" x=".5" y=".5" fill="#F8F9FA" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
-							<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+							<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 								<tspan x="12.068" y="22">Select a file</tspan>
 							</text>
 						</g>
@@ -33,7 +33,7 @@
 							<path id="Rectangle-1" d="M0 0h20v20H0z"/>
 						</g>
 					</g>
-					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal" transform="translate(16)">
+					<text id="Label" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal" transform="translate(16)">
 						<tspan x="0" y="15">Label</tspan>
 					</text>
 					<g id="_Spec-/-12-sp-(0.75-em)" stroke="#0082FF" stroke-width="4" transform="translate(304 39.5)">

--- a/img/components/file_inputs_intro.svg
+++ b/img/components/file_inputs_intro.svg
@@ -13,7 +13,7 @@
 					</g>
 					<g id="Button-/-!default-(--neutral)" transform="translate(287)">
 						<rect id="bg" width="112" height="31" x=".5" y=".5" fill="#F8F9FA" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
-						<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="12.068" y="22">Select a file</tspan>
 						</text>
 					</g>

--- a/img/components/file_inputs_select_button_only_intro.svg
+++ b/img/components/file_inputs_select_button_only_intro.svg
@@ -22,7 +22,7 @@
 								<path id="Rectangle-1" d="M0 0h20v20H0z"/>
 							</g>
 						</g>
-						<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue" font-size="16" font-weight="bold">
+						<text id="Label" fill="#222" font-family="HelveticaNeue-Bold, Helvetica Neue, sans-serif" font-size="16" font-weight="bold">
 							<tspan x="38" y="22">Select a file </tspan>
 						</text>
 					</g>

--- a/img/components/number_inputs_intro.svg
+++ b/img/components/number_inputs_intro.svg
@@ -18,7 +18,7 @@
 					<rect id="border" width="95" height="31" x=".5" y=".5" fill="#FFF" fill-rule="evenodd" stroke="#A2A9B1" stroke-width="1" rx="2"/>
 				</g>
 				<path id="Rectangle" fill="#FFF" d="M234 141h4v4h-4zm90 0h4v4h-4zm0-26h4v4h-4zm-90 0h4v4h-4z"/>
-				<text id="100" fill="#222" font-family="HelveticaNeue, Helvetica Neue" font-size="16" font-weight="normal">
+				<text id="100" fill="#222" font-family="HelveticaNeue, Helvetica Neue, sans-serif" font-size="16" font-weight="normal">
 					<tspan x="242" y="137">100</tspan>
 				</text>
 				<g id="🔣-Icon/Interactions/Subtract" transform="translate(207 120)">


### PR DESCRIPTION
Using fallback `sans-serif` across component images.