### PR TITLE
Fix Accent30 label

### DIFF
--- a/visual-style_colors.html
+++ b/visual-style_colors.html
@@ -231,7 +231,7 @@
 					<section id="accent-colors">
 						<h2>Accent colors</h2>
 						<p>Accent colors are used to emphasize actions and to highlight key information. Blue is a natural choice in our context, where it has been the default color used for links and conveys the idea of action.</p>
-						<p>There are three shades provided for when you need a lighter (Accent90), regular (Accent50) or a darker (Accent10) version of blue.</p>
+						<p>There are three shades provided for when you need a lighter (Accent90), regular (Accent50) or a darker (Accent30) version of blue.</p>
 						<p>Accent50 is suitable to use for text and as background. When used for link text, this color provides sufficient contrast with black text. When used as background, it provides sufficient contrast with white text.</p>
 							<ol class="color-palette color-section">
 							<li class="color" style="background-color: #eaf3ff;">
@@ -250,7 +250,7 @@
 								<code class="color-code color-code--hsb">HSB 220, 75%, 80%</code>
 							</li>
 							<li class="color color--dark" style="background-color: #2a4b8d;">
-								<strong class="color__name"><span>Accent</span>10</strong>
+								<strong class="color__name"><span>Accent</span>30</strong>
 								<code class="color-code color-code--hex">#2a4b8d</code>
 								<span class="color__wcag-level" title="WCAG conformance level">AAA</span>
 								<code class="color-code color-code--rgb">RGB 42, 75, 141</code>


### PR DESCRIPTION
On transfer between https://phabricator.wikimedia.org/M82 and
Design Style Guide the label was wrongly set to “Accent10” where
it should be similar to utility colors brightness equivalent colors.

Bug: (T249148)[https://phabricator.wikimedia.org/T249148]