### PR TITLE
build: Exclude 'principles-paper-ink.svg' from 'svgmin' Grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -328,7 +328,8 @@ module.exports = function ( grunt ) {
 					expand: true,
 					cwd: './',
 					src: [
-						'**/*.svg'
+						'**/*.svg',
+						'!img/visual-style/principles-paper-ink.svg'
 					],
 					dest: './',
 					ext: '.svg'


### PR DESCRIPTION
Binary images have been recurringly trouble-some in optimization.