### PR TITLE
“Resources”: Bump RSS to v1.5.0 to cast new Sketch version

### DIFF
--- a/resources/WikimediaUI-components_overview-RSS.xml
+++ b/resources/WikimediaUI-components_overview-RSS.xml
@@ -10,12 +10,12 @@
     <generator>Sketch</generator>
     <item>
       <title><![CDATA[WikimediaUI Components, Icons and Colors Library]]></title>
-      <pubDate>Fri, 10 Jan 2020 21:00:00 +0000</pubDate>
+      <pubDate>Wed, 15 Apr 2020 23:00:00 +0000</pubDate>
       <!--
         Use random token on update, for example with http://tools.andidittrich.de/Token.html
         Increase version on update
       -->
-      <enclosure url="https://design.wikimedia.org/style-guide/resources/WikimediaUI-components_overview.sketch?token=Taw4xjXNaJjdCnx4xmr9" type="application/octet-stream" sparkle:version="1.2.0"/>
+      <enclosure url="https://design.wikimedia.org/style-guide/resources/WikimediaUI-components_overview.sketch?token=umkHsCCMuNOITsbepPzR" type="application/octet-stream" sparkle:version="1.5.0"/>
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
Latest Sketch file includes among other changes
Base10 amendment.