### PR TITLE
“Components”: Fix inline validation link on Messages page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ $ npm run start
 Make sure the tests pass and the CSS for production is built:
 
 ```console
+$ npm run test
 $ npm run build
 ```
 

--- a/components/messages.html
+++ b/components/messages.html
@@ -76,7 +76,7 @@
 				<main id="content" class="content">
 					<div class="page__parent-title">Components</div>
 					<h1 class="page__title">Messages</h1>
-					<p class="page__lead">Messages to the user as system feedback can be delivered as block message with a longer explanation. The block messages, predominantly used in top or banner positions in the view are defined on this page. Or as inline message directly to a user input widget. Please go to <a href="inputs-with-validation.html">inputs with validation for inline validation messages</a>.</p>
+					<p class="page__lead">Messages to the user as system feedback can be delivered as block message with a longer explanation. The block messages, predominantly used in top or banner positions in the view are defined on this page. Or as inline message directly to a user input widget. For inline validation messages, see <a href="text-inputs-and-textarea.html#designing">designing text inputs</a>.</p>
 					<figure class="components__intro">
 						<img src="../img/components/messages_notice.svg" alt="Block message of neutral type visual example">
 					</figure>


### PR DESCRIPTION
- fix: Broken link to inline validation https://phabricator.wikimedia.org/T255944
- docs: Add command for testing as it is referenced in previous line