### PR TITLE
nav: Add missing link

### DIFF
--- a/components/messages.html
+++ b/components/messages.html
@@ -61,6 +61,7 @@
 								<li class="nav__sub-item"><a href="number-inputs.html">Number inputs</a></li>
 								<li class="nav__sub-item"><a href="file-inputs.html">File inputs</a></li>
 								<li class="nav__sub-item is-on"><a href="messages.html">Messages</a></li>
+								<li class="nav__sub-item"><a href="language-selectors.html">Language selectors</a></li>
 							</ul>
 						</li>
 						<!-- <li><a href="../patterns.html">Patterns</a></li> -->


### PR DESCRIPTION
Was missing due to search and replace not taking `is-on` class into
account.