### PR TITLE
build: Add and use 'browserslist-config-wikimedia'

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,8 +1,7 @@
-Android >= 4.3
-Chrome >= 31
-Edge >= 12
-Firefox >= 27
-IE >= 9
-iOS >= 9.0
-Opera >= 18
-Safari >= 9.1
+# Browserslist configuration of browsers with basic level of support.
+# Please see https://www.mediawiki.org/wiki/Compatibility#Mobile and
+# https://github.com/wikimedia/browserslist-config-wikimedia/
+# See also browsers definition in ResourceLoader startup module
+# in MediaWiki core 'resources/src/startup/startup.js'.
+
+extends browserslist-config-wikimedia/basic

--- a/package-lock.json
+++ b/package-lock.json
@@ -1137,6 +1137,12 @@
 				"node-releases": "^1.1.71"
 			}
 		},
+		"browserslist-config-wikimedia": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/browserslist-config-wikimedia/-/browserslist-config-wikimedia-0.2.0.tgz",
+			"integrity": "sha512-vIF9Nk1eAgvTAmY3mXUQ67rHIMFla4DsM5ohOt7AgUw/2YsNNnNFdRdDW7CI46FWdjexbeM9uW30Y/vwQTts6Q==",
+			"dev": true
+		},
 		"buffer": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	"devDependencies": {
 		"@lodder/grunt-postcss": "3.0.1",
 		"autoprefixer": "10.2.5",
+		"browserslist-config-wikimedia": "0.2.0",
 		"cssnano": "5.0.2",
 		"eslint-config-wikimedia": "0.20.0",
 		"grunt": "1.4.0",


### PR DESCRIPTION
Use central, shareable `browserslist-config-wikimedia/basic` config.

Bug: [T282937](https://phabricator.wikimedia.org/T282937)