### PR TITLE
build: Remove abandoned 'grunt-sketch' package

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,6 @@ module.exports = function ( grunt ) {
 	grunt.loadNpmTasks( 'grunt-eslint' );
 	grunt.loadNpmTasks( '@lodder/grunt-postcss' );
 	grunt.loadNpmTasks( 'grunt-replace' );
-	grunt.loadNpmTasks( 'grunt-sketch' );
 	grunt.loadNpmTasks( 'grunt-stylelint' );
 	grunt.loadNpmTasks( 'grunt-svgmin' );
 
@@ -108,181 +107,6 @@ module.exports = function ( grunt ) {
 				},
 				src: 'css/wmui-style-guide.dev.css',
 				dest: 'css/build/wmui-style-guide.min.css'
-			}
-		},
-
-		// Export resources from Sketch files
-		sketch_export: {
-			wikimediaui_components_png: {
-				options: {
-					type: 'slices',
-					items: [
-						'Primary_Buttons',
-						'Quiet_Buttons',
-						'Button_Group',
-						'Link',
-						'Checkbox',
-						'Radio_Button',
-						'Toggle_Switch',
-						'Text_Input',
-						'Dropdown'
-					],
-					groupContentsOnly: true,
-					scales: [
-						2.0
-					],
-					formats: [
-						'png'
-					],
-					saveForWeb: true
-				},
-				src: 'resources/WikimediaUI-components_overview.sketch',
-				dest: 'img/components'
-			},
-			wikimediaui_components_svg: {
-				options: {
-					type: 'slices',
-					items: [
-						'Primary_Buttons',
-						'Quiet_Buttons',
-						'Button_Group',
-						'Link',
-						'Checkbox',
-						'Radio_Button',
-						'Toggle_Switch',
-						'Text_Input',
-						'Dropdown',
-						'Language_Selectors'
-					],
-					groupContentsOnly: true,
-					compact: true,
-					scales: [
-						1.0
-					],
-					formats: [
-						'svg'
-					],
-					saveForWeb: true
-				},
-				src: 'resources/WikimediaUI-components_overview.sketch',
-				dest: 'img/components'
-			},
-			wikimediaui_overview: {
-				options: {
-					type: 'artboards',
-					items: [
-						'WikimediaUI-components_overview'
-					],
-					groupContentsOnly: true,
-					compact: true,
-					scales: [
-						1.0
-					],
-					formats: [
-						'png',
-						'svg'
-					],
-					saveForWeb: true
-				},
-				src: 'resources/WikimediaUI-components_overview.sketch',
-				dest: 'resources'
-			},
-			wikimediaui_style_guide_imagery_design_principles_svg: {
-				options: {
-					type: 'artboards',
-					items: [
-						'content-first',
-						'trustworthy-yet-joyful'
-					],
-					groupContentsOnly: true,
-					compact: true,
-					scales: [
-						1.0
-					],
-					formats: [
-						'svg'
-					],
-					saveForWeb: true
-				},
-				src: 'resources/Wikimedia_Design_Style_Guide-imagery.sketch',
-				dest: 'img/design-principles'
-			},
-			wikimediaui_style_guide_imagery_design_principles_png: {
-				options: {
-					type: 'artboards',
-					items: [
-						'content-first',
-						'trustworthy-yet-joyful'
-					],
-					groupContentsOnly: true,
-					compact: true,
-					scales: [
-						2.0
-					],
-					formats: [
-						'png'
-					],
-					saveForWeb: true
-				},
-				src: 'resources/Wikimedia_Design_Style_Guide-imagery.sketch',
-				dest: 'img/design-principles'
-			},
-			wikimediaui_style_guide_imagery_visual_style_svg: {
-				options: {
-					type: 'artboards',
-					items: [
-						'icons-sample',
-						'icons-optical-adjustment',
-						'illustrations-header',
-						'illustrations-article',
-						'illustrations-colored-background',
-						'illustrations-white-background',
-						'illustrations-grey-background'
-					],
-					groupContentsOnly: true,
-					compact: true,
-					scales: [
-						1.0
-					],
-					formats: [
-						'svg'
-					],
-					saveForWeb: true
-				},
-				src: 'resources/Wikimedia_Design_Style_Guide-imagery.sketch',
-				dest: 'img/visual-style'
-			},
-			wikimediaui_style_guide_imagery_visual_style_png: {
-				options: {
-					type: 'artboards',
-					items: [
-						'principles-paper-ink',
-						'principles-paper-shadow',
-						'principles-content-chrome',
-						'principles-color-type',
-						'typography-specimen',
-						'typography-readability',
-						'icons-sample',
-						'icons-optical-adjustment',
-						'illustrations-header',
-						'illustrations-article',
-						'illustrations-colored-background',
-						'illustrations-white-background',
-						'illustrations-grey-background'
-
-					],
-					groupContentsOnly: true,
-					compact: true,
-					scales: [
-						2.0
-					],
-					formats: [
-						'png'
-					],
-					saveForWeb: true
-				},
-				src: 'resources/Wikimedia_Design_Style_Guide-imagery.sketch',
-				dest: 'img/visual-style'
 			}
 		},
 
@@ -376,7 +200,7 @@ module.exports = function ( grunt ) {
 	} );
 
 	grunt.registerTask( 'lint', [ 'eslint', 'stylelint' ] );
-	grunt.registerTask( 'images', [ 'sketch_export', 'svgmin' ] );
+	grunt.registerTask( 'images', [ 'svgmin' ] );
 	grunt.registerTask( 'images-pre-production', [ 'replace' ] );
 	grunt.registerTask( 'default', [ 'concat', 'uglify', 'postcss:dev', 'postcss:min' ] );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,20 +20,20 @@
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
-			"integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
+			"version": "7.14.3",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
+			"integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.14.0",
+				"@babel/generator": "^7.14.3",
 				"@babel/helper-compilation-targets": "^7.13.16",
-				"@babel/helper-module-transforms": "^7.14.0",
+				"@babel/helper-module-transforms": "^7.14.2",
 				"@babel/helpers": "^7.14.0",
-				"@babel/parser": "^7.14.0",
+				"@babel/parser": "^7.14.3",
 				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.14.0",
-				"@babel/types": "^7.14.0",
+				"@babel/traverse": "^7.14.2",
+				"@babel/types": "^7.14.2",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -57,12 +57,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.0.tgz",
-			"integrity": "sha512-C6u00HbmsrNPug6A+CiNl8rEys7TsdcXwg12BHi2ca5rUfAs3+UwZsuDQSXnc+wCElCXMB8gMaJ3YXDdh8fAlg==",
+			"version": "7.14.3",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
+			"integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.14.0",
+				"@babel/types": "^7.14.2",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			},
@@ -96,14 +96,14 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.12.13",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-			"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+			"version": "7.14.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
+			"integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.12.13",
 				"@babel/template": "^7.12.13",
-				"@babel/types": "^7.12.13"
+				"@babel/types": "^7.14.2"
 			}
 		},
 		"@babel/helper-get-function-arity": {
@@ -134,9 +134,9 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz",
-			"integrity": "sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==",
+			"version": "7.14.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
+			"integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.13.12",
@@ -145,8 +145,8 @@
 				"@babel/helper-split-export-declaration": "^7.12.13",
 				"@babel/helper-validator-identifier": "^7.14.0",
 				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.14.0",
-				"@babel/types": "^7.14.0"
+				"@babel/traverse": "^7.14.2",
+				"@babel/types": "^7.14.2"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -159,15 +159,15 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.13.12",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
-			"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+			"version": "7.14.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.3.tgz",
+			"integrity": "sha512-Rlh8qEWZSTfdz+tgNV/N4gz1a0TMNwCUcENhMjHTHKp3LseYH5Jha0NSlyTQWMnjbYcwFt+bqAMqSLHVXkQ6UA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.13.12",
 				"@babel/helper-optimise-call-expression": "^7.12.13",
-				"@babel/traverse": "^7.13.0",
-				"@babel/types": "^7.13.12"
+				"@babel/traverse": "^7.14.2",
+				"@babel/types": "^7.14.2"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -275,9 +275,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.0.tgz",
-			"integrity": "sha512-AHbfoxesfBALg33idaTBVUkLnfXtsgvJREf93p4p0Lwsz4ppfE7g1tpEXVm4vrxUcH4DVhAa9Z1m1zqf9WUC7Q==",
+			"version": "7.14.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.3.tgz",
+			"integrity": "sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ==",
 			"dev": true
 		},
 		"@babel/template": {
@@ -292,17 +292,17 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.0.tgz",
-			"integrity": "sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==",
+			"version": "7.14.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
+			"integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.14.0",
-				"@babel/helper-function-name": "^7.12.13",
+				"@babel/generator": "^7.14.2",
+				"@babel/helper-function-name": "^7.14.2",
 				"@babel/helper-split-export-declaration": "^7.12.13",
-				"@babel/parser": "^7.14.0",
-				"@babel/types": "^7.14.0",
+				"@babel/parser": "^7.14.2",
+				"@babel/types": "^7.14.2",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -316,9 +316,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.0.tgz",
-			"integrity": "sha512-O2LVLdcnWplaGxiPBz12d0HcdN8QdxdsWYhz5LSeuukV/5mn2xUUc3gBeU4QBYPJ18g/UToe8F532XJ608prmg==",
+			"version": "7.14.2",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
+			"integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.14.0",
@@ -326,9 +326,9 @@
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
-			"integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
+			"integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
@@ -1304,9 +1304,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001220",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001220.tgz",
-			"integrity": "sha512-pjC2T4DIDyGAKTL4dMvGUQaMUHRmhvPpAgNNTa14jaBWHu+bLQgvpFqElxh9L4829Fdx0PlKiMp3wnYldRtECA==",
+			"version": "1.0.30001230",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+			"integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
 			"dev": true
 		},
 		"caw": {
@@ -1487,6 +1487,34 @@
 				"object-visit": "^1.0.0"
 			}
 		},
+		"color": {
+			"version": "0.11.4",
+			"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+			"dev": true,
+			"requires": {
+				"clone": "^1.0.2",
+				"color-convert": "^1.3.0",
+				"color-string": "^0.3.0"
+			},
+			"dependencies": {
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				}
+			}
+		},
 		"color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1503,13 +1531,12 @@
 			"dev": true
 		},
 		"color-string": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-			"integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
 			"dev": true,
 			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
+				"color-name": "^1.0.0"
 			}
 		},
 		"colord": {
@@ -1617,9 +1644,9 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "3.11.1",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.1.tgz",
-			"integrity": "sha512-k93Isqg7e4txZWMGNYwevZL9MiogLk8pd1PtwrmFmi8IBq4GXqUaVW/a33Llt6amSI36uSjd0GWwc9pTT9ALlQ==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.0.tgz",
+			"integrity": "sha512-iWDbiyha1M5vFwPFmQnvRv+tJzGbFAm6XimJUT0NgHYW3xZEs1SkCAcasWSVFxpI2Xb/V1DDJckq3v90+bQnog==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -1679,41 +1706,6 @@
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
 					"integrity": "sha1-tQS9BYabOSWd0MXvw12EMXbczEo=",
 					"dev": true
-				},
-				"color": {
-					"version": "0.11.4",
-					"resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
-					"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-					"dev": true,
-					"requires": {
-						"clone": "^1.0.2",
-						"color-convert": "^1.3.0",
-						"color-string": "^0.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"color-string": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-					"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-					"dev": true,
-					"requires": {
-						"color-name": "^1.0.0"
-					}
 				},
 				"debug": {
 					"version": "3.2.7",
@@ -2357,9 +2349,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.725",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.725.tgz",
-			"integrity": "sha512-2BbeAESz7kc6KBzs7WVrMc1BY5waUphk4D4DX5dSQXJhsc3tP5ZFaiyuL0AB7vUKzDYpIeYwTYlEfxyjsGUrhw==",
+			"version": "1.3.738",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.738.tgz",
+			"integrity": "sha512-vCMf4gDOpEylPSLPLSwAEsz+R3ShP02Y3cAKMZvTqule3XcPp7tgc/0ESI7IS6ZeyBlGClE50N53fIOkcIVnpw==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -2411,9 +2403,9 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-			"integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+			"version": "1.18.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.2.tgz",
+			"integrity": "sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
@@ -2424,14 +2416,14 @@
 				"has-symbols": "^1.0.2",
 				"is-callable": "^1.2.3",
 				"is-negative-zero": "^2.0.1",
-				"is-regex": "^1.1.2",
-				"is-string": "^1.0.5",
-				"object-inspect": "^1.9.0",
+				"is-regex": "^1.1.3",
+				"is-string": "^1.0.6",
+				"object-inspect": "^1.10.3",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
 				"string.prototype.trimend": "^1.0.4",
 				"string.prototype.trimstart": "^1.0.4",
-				"unbox-primitive": "^1.0.0"
+				"unbox-primitive": "^1.0.1"
 			}
 		},
 		"es-to-primitive": {
@@ -2458,25 +2450,27 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
-			"integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.27.0.tgz",
+			"integrity": "sha512-JZuR6La2ZF0UD384lcbnd0Cgg6QJjiCwhMD6eU4h/VGPcVGwawNNzKU41tgokGXnfjOOyI6QIffthhJTPzzuRA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.0",
+				"@eslint/eslintrc": "^0.4.1",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
 				"enquirer": "^2.3.5",
+				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^2.1.0",
 				"eslint-visitor-keys": "^2.0.0",
 				"espree": "^7.3.1",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^5.0.0",
@@ -2488,7 +2482,7 @@
 				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
-				"lodash": "^4.17.21",
+				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.0.4",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.1",
@@ -2497,7 +2491,7 @@
 				"semver": "^7.2.1",
 				"strip-ansi": "^6.0.0",
 				"strip-json-comments": "^3.1.0",
-				"table": "^6.0.4",
+				"table": "^6.0.9",
 				"text-table": "^0.2.0",
 				"v8-compile-cache": "^2.0.3"
 			},
@@ -2510,6 +2504,12 @@
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
 				}
 			}
 		},
@@ -2603,9 +2603,9 @@
 			}
 		},
 		"eslint-plugin-mocha": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",
-			"integrity": "sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.2.0.tgz",
+			"integrity": "sha512-8oOR47Ejt+YJPNQzedbiklDqS1zurEaNrxXpRs+Uk4DMDPVmKNagShFeUaYsfvWP55AhI+P1non5QZAHV6K78A==",
 			"dev": true,
 			"requires": {
 				"eslint-utils": "^2.1.0",
@@ -2657,13 +2657,24 @@
 			}
 		},
 		"eslint-plugin-qunit": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.1.0.tgz",
-			"integrity": "sha512-FT101NNIwxyFiznlORzjhV9uSvl4JXDdNUyiMEHedMqvdTv0z5kOjaNv3UlFq5uL7znPlz23RmJUtPxw3fH3HA==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-qunit/-/eslint-plugin-qunit-6.1.1.tgz",
+			"integrity": "sha512-XAEULG0Std1wtAZrFDzL//TcJDQhLBOe2DeZDCQ4fxjbk9grDkKaWh4xpNhPQdCp4cL0Wx3PVE2yP7s4VCMH2g==",
 			"dev": true,
 			"requires": {
-				"eslint-utils": "^2.1.0",
+				"eslint-utils": "^3.0.0",
 				"requireindex": "^1.2.0"
+			},
+			"dependencies": {
+				"eslint-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^2.0.0"
+					}
+				}
 			}
 		},
 		"eslint-plugin-vue": {
@@ -2712,9 +2723,9 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-			"integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 			"dev": true
 		},
 		"espree": {
@@ -3453,9 +3464,9 @@
 			}
 		},
 		"fraction.js": {
-			"version": "4.0.13",
-			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
-			"integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
+			"integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
 			"dev": true
 		},
 		"fragment-cache": {
@@ -3663,9 +3674,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -4255,31 +4266,6 @@
 				"chalk": "^4.1.0",
 				"file-sync-cmp": "^0.1.0",
 				"lodash": "^4.17.21"
-			}
-		},
-		"grunt-sketch": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/grunt-sketch/-/grunt-sketch-1.0.5.tgz",
-			"integrity": "sha1-c6tSkKHFwL7tpC0QkrFhCr29OOU=",
-			"dev": true,
-			"requires": {
-				"async": "~0.8.0",
-				"underscore": "~1.6.0",
-				"which": "~1.0.5"
-			},
-			"dependencies": {
-				"async": {
-					"version": "0.8.0",
-					"resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz",
-					"integrity": "sha1-7mXsdymML/FFa8RBigUtDwZDURI=",
-					"dev": true
-				},
-				"which": {
-					"version": "1.0.9",
-					"resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-					"integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8=",
-					"dev": true
-				}
 			}
 		},
 		"grunt-stylelint": {
@@ -5232,18 +5218,18 @@
 			"dev": true
 		},
 		"is-bigint": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
-			"integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
 			"dev": true
 		},
 		"is-boolean-object": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
-			"integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			}
 		},
 		"is-buffer": {
@@ -5281,9 +5267,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
-			"integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -5310,9 +5296,9 @@
 			}
 		},
 		"is-date-object": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+			"integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
 			"dev": true
 		},
 		"is-decimal": {
@@ -5415,9 +5401,9 @@
 			"dev": true
 		},
 		"is-number-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-			"integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
 			"dev": true
 		},
 		"is-object": {
@@ -5449,13 +5435,13 @@
 			"optional": true
 		},
 		"is-regex": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
-			"integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+			"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
 			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"has-symbols": "^1.0.1"
+				"has-symbols": "^1.0.2"
 			}
 		},
 		"is-regexp": {
@@ -5492,9 +5478,9 @@
 			"dev": true
 		},
 		"is-string": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
 			"dev": true
 		},
 		"is-svg": {
@@ -5508,12 +5494,12 @@
 			}
 		},
 		"is-symbol": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
 			"dev": true,
 			"requires": {
-				"has-symbols": "^1.0.1"
+				"has-symbols": "^1.0.2"
 			}
 		},
 		"is-typedarray": {
@@ -5844,16 +5830,16 @@
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 			"dev": true
 		},
-		"lodash.flatten": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-			"dev": true
-		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+			"dev": true
+		},
+		"lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
 		"lodash.template": {
@@ -6315,9 +6301,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "1.1.71",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+			"version": "1.1.72",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+			"integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
 			"dev": true
 		},
 		"nopt": {
@@ -6466,9 +6452,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
-			"integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 			"dev": true
 		},
 		"object-keys": {
@@ -6800,9 +6786,9 @@
 			"dev": true
 		},
 		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
 		"path-root": {
@@ -6839,9 +6825,9 @@
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-			"integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+			"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
 			"dev": true
 		},
 		"pify": {
@@ -7361,6 +7347,16 @@
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
+				"color-string": {
+					"version": "1.5.5",
+					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+					"integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+					"dev": true,
+					"requires": {
+						"color-name": "^1.0.0",
+						"simple-swizzle": "^0.2.2"
+					}
+				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -7444,6 +7440,16 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
+				},
+				"color-string": {
+					"version": "1.5.5",
+					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+					"integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+					"dev": true,
+					"requires": {
+						"color-name": "^1.0.0",
+						"simple-swizzle": "^0.2.2"
+					}
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -7609,6 +7615,16 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
+				},
+				"color-string": {
+					"version": "1.5.5",
+					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+					"integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+					"dev": true,
+					"requires": {
+						"color-name": "^1.0.0",
+						"simple-swizzle": "^0.2.2"
+					}
 				},
 				"has-flag": {
 					"version": "3.0.0",
@@ -9773,9 +9789,9 @@
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.5.tgz",
-			"integrity": "sha512-aFYPoYmXbZ1V6HZaSvat08M97A8HqO6Pjz+PiNpw/DhuRrC72XWAdp3hL6wusDCN31sSmcZyMGa2hZEuX+Xfhg==",
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+			"integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
 			"dev": true,
 			"requires": {
 				"cssesc": "^3.0.0",
@@ -10450,12 +10466,6 @@
 				}
 			}
 		},
-		"sketchtool": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/sketchtool/-/sketchtool-1.4.0.tgz",
-			"integrity": "sha1-Jw/iRKNI3mKhaVpbVDAyA3ppasI=",
-			"dev": true
-		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -10677,9 +10687,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-			"integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+			"integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==",
 			"dev": true
 		},
 		"specificity": {
@@ -11535,14 +11545,13 @@
 			}
 		},
 		"table": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/table/-/table-6.6.0.tgz",
-			"integrity": "sha512-iZMtp5tUvcnAdtHpZTWLPF0M7AgiQsURR2DwmxnJwSy8I3+cY+ozzVvYha3BOLG2TB+L0CqjIz+91htuj6yCXg==",
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+			"integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
 			"dev": true,
 			"requires": {
 				"ajv": "^8.0.1",
 				"lodash.clonedeep": "^4.5.0",
-				"lodash.flatten": "^4.4.0",
 				"lodash.truncate": "^4.4.2",
 				"slice-ansi": "^4.0.0",
 				"string-width": "^4.2.0",
@@ -11550,9 +11559,9 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "8.2.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.2.0.tgz",
-					"integrity": "sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==",
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+					"integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
 					"dev": true,
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
@@ -11789,9 +11798,9 @@
 			}
 		},
 		"uglify-js": {
-			"version": "3.13.5",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.5.tgz",
-			"integrity": "sha512-xtB8yEqIkn7zmOyS2zUNBsYCBRhDkvlNxMMY2smuJ/qA8NCHeQvKCF3i9Z4k8FJH4+PJvZRtMrPynfZ75+CSZw==",
+			"version": "3.13.7",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.7.tgz",
+			"integrity": "sha512-1Psi2MmnZJbnEsgJJIlfnd7tFlJfitusmR7zDI8lXlFI0ACD4/Rm/xdrU8bh6zF0i74aiVoBtkRiFulkrmh3AA==",
 			"dev": true
 		},
 		"unbox-primitive": {
@@ -11820,12 +11829,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
 			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-			"dev": true
-		},
-		"underscore": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-			"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
 			"dev": true
 		},
 		"underscore.string": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 		"grunt-eslint": "23.0.0",
 		"grunt-exec": "3.0.0",
 		"grunt-replace": "2.0.2",
-		"grunt-sketch": "1.0.5",
 		"grunt-stylelint": "0.16.0",
 		"grunt-svgmin": "6.0.1",
 		"imagemin": "8.0.0",
@@ -41,7 +40,6 @@
 		"postcss-cssnext": "3.1.0",
 		"postcss-custom-properties": "11.0.0",
 		"postcss-import": "14.0.2",
-		"sketchtool": "1.4.0",
 		"stylelint-config-wikimedia": "0.10.3"
 	},
 	"scripts": {


### PR DESCRIPTION
Abandoning 'grunt-sketch' with Figma on the brink. Will slowly
provide similar automated export steps to Figma resourcing over time.
For now manual exporting is sufficient.

Bug: [T205666](https://phabricator.wikimedia.org/T205666)