### PR TITLE
“Resources”: Fix illustration building blocks links

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -130,7 +130,7 @@
 						</header>
 						<ul class="resources-table__body">
 							<li class="resources-table__cell">Wikimedia illustrations building blocks<br>A set of illustrations that can be mixed and matched to communicate core principles or features. </li>
-							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI_illustrations-building-blocks.sketch" target="_blank" rel="noopener" title="Wikimedia illustrations building blocks Sketch file">Download Sketch</a></li>
+							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI_illustrations-building-block.sketch" target="_blank" rel="noopener" title="Wikimedia illustrations building blocks Sketch file">Download Sketch</a></li>
 							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI_illustrations-building-blocks.zip" target="_blank" rel="noopener" title="Wikimedia illustrations building blocks SVGs">Download ZIP of SVGs</a></li>
 						</ul>
 					</section>

--- a/resources.html
+++ b/resources.html
@@ -130,7 +130,7 @@
 						</header>
 						<ul class="resources-table__body">
 							<li class="resources-table__cell">Wikimedia illustrations building blocks<br>A set of illustrations that can be mixed and matched to communicate core principles or features. </li>
-							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI_illustrations-building-block.sketch" target="_blank" rel="noopener" title="Wikimedia illustrations building blocks Sketch file">Download Sketch</a></li>
+							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI_illustrations-building-blocks.sketch" target="_blank" rel="noopener" title="Wikimedia illustrations building blocks Sketch file">Download Sketch</a></li>
 							<li class="resources-table__cell"><a class="lnk-resource" href="resources/WikimediaUI_illustrations-building-blocks.zip" target="_blank" rel="noopener" title="Wikimedia illustrations building blocks SVGs">Download ZIP of SVGs</a></li>
 						</ul>
 					</section>

--- a/visual-style_illustrations.html
+++ b/visual-style_illustrations.html
@@ -112,7 +112,7 @@
 
 					<section id="resources">
 						<h2>Resources</h2>
-						<p>Find the Wikimedia illustration building blocks under <a href="resources.html">“Resources”</a> or directly here as <a href="resources/WikimediaUI_building-block-illustrations.sketch" target="_blank" rel="noopener">Sketch source file</a> or as collection of <a href="resources/WikimediaUI_building-block-illustrations" target="_blank" rel="noopener">SVGs in a ZIP file</a>.</p>
+						<p>Find the Wikimedia illustration building blocks under <a href="resources.html">“Resources”</a> or directly here as <a href="resources/WikimediaUI_illustrations-building-block.sketch" target="_blank" rel="noopener">Sketch source file</a> or as collection of <a href="resources/WikimediaUI_illustrations-building-blocks.zip" target="_blank" rel="noopener">SVGs in a ZIP file</a>.</p>
 					</section>
 				</main>
 			</div>

--- a/visual-style_illustrations.html
+++ b/visual-style_illustrations.html
@@ -112,7 +112,7 @@
 
 					<section id="resources">
 						<h2>Resources</h2>
-						<p>Find the Wikimedia illustration building blocks under <a href="resources.html">“Resources”</a> or directly here as <a href="resources/WikimediaUI_illustrations-building-block.sketch" target="_blank" rel="noopener">Sketch source file</a> or as collection of <a href="resources/WikimediaUI_illustrations-building-blocks.zip" target="_blank" rel="noopener">SVGs in a ZIP file</a>.</p>
+						<p>Find the Wikimedia illustration building blocks under <a href="resources.html">“Resources”</a> or directly here as <a href="resources/WikimediaUI_illustrations-building-blocks.sketch" target="_blank" rel="noopener">Sketch source file</a> or as collection of <a href="resources/WikimediaUI_illustrations-building-blocks.zip" target="_blank" rel="noopener">SVGs in a ZIP file</a>.</p>
 					</section>
 				</main>
 			</div>


### PR DESCRIPTION
Some links to the illustration resources were broken