### PR TITLE
“Visual style – Typography“: Remove note on printing costs

### DIFF
--- a/visual-style_typography.html
+++ b/visual-style_typography.html
@@ -108,7 +108,7 @@
 						<ol>
 							<li><b>Readability.</b> Fonts with a bigger x-height and open shapes are preferred.</li>
 							<li><b>Neutral aspect.</b> The font should work with many different kinds of content without adding a particular voice to it.</li>
-							<li><b>Simple shapes.</b> Fonts with less complex shapes work better at smaller sizes, on low-resolution devices, and reduce printing costs.</li>
+							<li><b>Simple shapes.</b> Fonts with less complex shapes work better at smaller sizes and on low-resolution devices.</li>
 							<li><b>Open.</b> Open source fonts are preferred to align with the open knowledge they deliver.</li>
 						</ol>
 


### PR DESCRIPTION
While this might be true, reducing printable elements or boldening
has a significant higher impact and the cost reduction is not
data-backed hence removing.

Bug: [T282679](https://phabricator.wikimedia.org/T282679)