### PR TITLE
“Apps”: Fix image path

### DIFF
--- a/apps/apps.html
+++ b/apps/apps.html
@@ -210,7 +210,7 @@
 						<h3>Focus</h3>
 						<div class="figures-box">
 							<figure class="apps__principles figure figure--comparison">
-								<img src="../img/apps/principles_focus-Android-picture_of_the_day.png" alt="Wikipedia for Android app: picture of the day">
+								<img src="../img/apps/principles_focus-android-picture_of_the_day.png" alt="Wikipedia for Android app: picture of the day">
 								<figcaption class="figure__caption">The “Picture of the day” on Wikipedia for Android puts content from Wikimedia Commons in the
 								spotlight</figcaption>
 							</figure>


### PR DESCRIPTION
Was falsely remaining as uppercase 'Android' while local file was
lowercased.