### PR TITLE
build: Replace 'grunt-svgmin' with npm based 'svgo'

### DIFF
--- a/.svgo.config.js
+++ b/.svgo.config.js
@@ -1,0 +1,40 @@
+/**
+ * SVGO Configuration
+ * Compatible to v2.4.0+
+ * Recommended options from:
+ * https://www.mediawiki.org/wiki/Manual:Coding_conventions/SVG#Exemplified_safe_configuration
+ */
+module.exports = {
+	plugins: [
+		{
+			// Set of built-in plugins enabled by default.
+			name: 'preset-default',
+			params: {
+				overrides: {
+					cleanupIDs: false,
+					removeDesc: false,
+					removeTitle: false,
+					removeViewBox: false,
+					// If the SVG doesn't start with an XML declaration, then its MIME type will
+					// be detected as "text/plain" rather than "image/svg+xml" by libmagic and,
+					// consequently, MediaWiki's CSSMin CSS minifier. libmagic's default database
+					// currently requires that SVGs contain an XML declaration:
+					// https://github.com/threatstack/libmagic/blob/master/magic/Magdir/sgml#L5
+					removeXMLProcInst: false
+				}
+			}
+		},
+		'removeRasterImages',
+		'sortAttrs'
+	],
+	// Set whitespace according to Wikimedia Coding Conventions.
+	// @see https://github.com/svg/svgo/blob/main/lib/svgo/coa.js#L194 for more config options
+	js2svg: {
+		eol: 'lf',
+		finalNewline: true,
+		// Configure the indent to tabs (default 4 spaces) used by `--pretty` here.
+		indent: '\t',
+		pretty: true
+	},
+	multipass: true
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,7 +28,6 @@ module.exports = function ( grunt ) {
 	grunt.loadNpmTasks( '@lodder/grunt-postcss' );
 	grunt.loadNpmTasks( 'grunt-replace' );
 	grunt.loadNpmTasks( 'grunt-stylelint' );
-	grunt.loadNpmTasks( 'grunt-svgmin' );
 
 	grunt.initConfig( {
 		// Build – JavaScript
@@ -108,43 +107,6 @@ module.exports = function ( grunt ) {
 			}
 		},
 
-		svgmin: {
-			options: {
-				js2svg: {
-					indent: '\t',
-					multipass: true,
-					pretty: true
-				},
-				plugins: [ {
-					cleanupIDs: false
-				}, {
-					removeDesc: true
-				}, {
-					removeRasterImages: true
-				}, {
-					removeTitle: false
-				}, {
-					removeViewBox: false
-				}, {
-					removeXMLProcInst: false
-				}, {
-					sortAttrs: true
-				} ]
-			},
-			all: {
-				files: [ {
-					expand: true,
-					cwd: './',
-					src: [
-						'**/*.svg',
-						'!img/visual-style/principles-paper-ink.svg'
-					],
-					dest: './',
-					ext: '.svg'
-				} ]
-			}
-		},
-
 		replace: {
 			dist: {
 				options: {
@@ -183,7 +145,6 @@ module.exports = function ( grunt ) {
 	} );
 
 	grunt.registerTask( 'lint', [ 'eslint', 'stylelint' ] );
-	grunt.registerTask( 'images', [ 'svgmin' ] );
 	grunt.registerTask( 'images-pre-production', [ 'replace' ] );
 	grunt.registerTask( 'default', [ 'concat', 'uglify', 'postcss:dev', 'postcss:min' ] );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -442,9 +442,9 @@
 			}
 		},
 		"@trysound/sax": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.1.1.tgz",
-			"integrity": "sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+			"integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
 			"dev": true
 		},
 		"@types/mdast": {
@@ -478,12 +478,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-			"dev": true
-		},
-		"@types/q": {
-			"version": "1.5.4",
-			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
-			"integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
 			"dev": true
 		},
 		"@types/unist": {
@@ -856,69 +850,6 @@
 				"is-regexp": "^2.0.0"
 			}
 		},
-		"coa": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
-			"integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
-			"dev": true,
-			"requires": {
-				"@types/q": "^1.5.1",
-				"chalk": "^2.4.1",
-				"q": "^1.1.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
 		"coffeescript": {
 			"version": "1.12.7",
 			"resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
@@ -1176,23 +1107,17 @@
 			}
 		},
 		"css-select": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
-			"integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
+			"integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
 			"dev": true,
 			"requires": {
 				"boolbase": "^1.0.0",
-				"css-what": "^5.0.0",
-				"domhandler": "^4.2.0",
-				"domutils": "^2.6.0",
-				"nth-check": "^2.0.0"
+				"css-what": "^5.1.0",
+				"domhandler": "^4.3.0",
+				"domutils": "^2.8.0",
+				"nth-check": "^2.0.1"
 			}
-		},
-		"css-select-base-adapter": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
-			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
-			"dev": true
 		},
 		"css-tokenize": {
 			"version": "1.0.1",
@@ -1247,9 +1172,9 @@
 			"dev": true
 		},
 		"css-what": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
-			"integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+			"integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
 			"dev": true
 		},
 		"cssesc": {
@@ -1367,15 +1292,6 @@
 				"clone": "^1.0.2"
 			}
 		},
-		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
-			"requires": {
-				"object-keys": "^1.0.12"
-			}
-		},
 		"detect-file": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
@@ -1441,18 +1357,18 @@
 			"dev": true
 		},
 		"domhandler": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
-			"integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
+			"integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
 			"dev": true,
 			"requires": {
 				"domelementtype": "^2.2.0"
 			}
 		},
 		"domutils": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
-			"integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+			"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
 			"dev": true,
 			"requires": {
 				"dom-serializer": "^1.0.1",
@@ -1544,41 +1460,6 @@
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
-			}
-		},
-		"es-abstract": {
-			"version": "1.18.3",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
-			"integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"es-to-primitive": "^1.2.1",
-				"function-bind": "^1.1.1",
-				"get-intrinsic": "^1.1.1",
-				"has": "^1.0.3",
-				"has-symbols": "^1.0.2",
-				"is-callable": "^1.2.3",
-				"is-negative-zero": "^2.0.1",
-				"is-regex": "^1.1.3",
-				"is-string": "^1.0.6",
-				"object-inspect": "^1.10.3",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.2",
-				"string.prototype.trimend": "^1.0.4",
-				"string.prototype.trimstart": "^1.0.4",
-				"unbox-primitive": "^1.0.1"
-			}
-		},
-		"es-to-primitive": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
-			"requires": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
 			}
 		},
 		"escalade": {
@@ -2661,177 +2542,6 @@
 				"chalk": "^4.1.0"
 			}
 		},
-		"grunt-svgmin": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/grunt-svgmin/-/grunt-svgmin-6.0.1.tgz",
-			"integrity": "sha512-NmVF57+Un8oiq8ZVJQJEkomEeGMcq2Sd6OX/0k2tpUc5Y/+kXwgg6CDW9RA0Yr9jXOcfFE46CNKg0hBxp2SFiQ==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.2",
-				"log-symbols": "^2.2.0",
-				"pretty-bytes": "^5.1.0",
-				"svgo": "^1.2.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"css-select": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-					"integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
-					"dev": true,
-					"requires": {
-						"boolbase": "^1.0.0",
-						"css-what": "^3.2.1",
-						"domutils": "^1.7.0",
-						"nth-check": "^1.0.2"
-					}
-				},
-				"css-tree": {
-					"version": "1.0.0-alpha.37",
-					"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
-					"integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
-					"dev": true,
-					"requires": {
-						"mdn-data": "2.0.4",
-						"source-map": "^0.6.1"
-					}
-				},
-				"css-what": {
-					"version": "3.4.2",
-					"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-					"integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
-					"dev": true
-				},
-				"dom-serializer": {
-					"version": "0.2.2",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-					"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-					"dev": true,
-					"requires": {
-						"domelementtype": "^2.0.1",
-						"entities": "^2.0.0"
-					},
-					"dependencies": {
-						"domelementtype": {
-							"version": "2.2.0",
-							"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-							"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-							"dev": true
-						}
-					}
-				},
-				"domelementtype": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-					"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-					"dev": true
-				},
-				"domutils": {
-					"version": "1.7.0",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-					"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-					"dev": true,
-					"requires": {
-						"dom-serializer": "0",
-						"domelementtype": "1"
-					}
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"mdn-data": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-					"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
-				"nth-check": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-					"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-					"dev": true,
-					"requires": {
-						"boolbase": "~1.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"svgo": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
-					"integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.1",
-						"coa": "^2.0.2",
-						"css-select": "^2.0.0",
-						"css-select-base-adapter": "^0.1.1",
-						"css-tree": "1.0.0-alpha.37",
-						"csso": "^4.0.2",
-						"js-yaml": "^3.13.1",
-						"mkdirp": "~0.5.1",
-						"object.values": "^1.1.0",
-						"sax": "~1.2.4",
-						"stable": "^0.1.8",
-						"unquote": "~1.1.1",
-						"util.promisify": "~1.0.0"
-					}
-				}
-			}
-		},
 		"gzip-size": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -2873,12 +2583,6 @@
 					"dev": true
 				}
 			}
-		},
-		"has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-			"dev": true
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -3128,27 +2832,6 @@
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
 		},
-		"is-bigint": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
-			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
-			"dev": true
-		},
-		"is-boolean-object": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
-			"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2"
-			}
-		},
-		"is-callable": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-			"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-			"dev": true
-		},
 		"is-color-stop": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
@@ -3179,12 +2862,6 @@
 			"requires": {
 				"has": "^1.0.3"
 			}
-		},
-		"is-date-object": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
-			"integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
-			"dev": true
 		},
 		"is-decimal": {
 			"version": "1.0.4",
@@ -3225,22 +2902,10 @@
 			"integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
 			"dev": true
 		},
-		"is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-			"dev": true
-		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
-		},
-		"is-number-object": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
-			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
 			"dev": true
 		},
 		"is-plain-obj": {
@@ -3256,16 +2921,6 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
-			}
-		},
-		"is-regex": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-			"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"has-symbols": "^1.0.2"
 			}
 		},
 		"is-regexp": {
@@ -3288,21 +2943,6 @@
 			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
 			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
 			"dev": true
-		},
-		"is-string": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-			"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-			"dev": true
-		},
-		"is-symbol": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-			"dev": true,
-			"requires": {
-				"has-symbols": "^1.0.2"
-			}
 		},
 		"is-typedarray": {
 			"version": "1.0.0",
@@ -3596,67 +3236,6 @@
 			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
 		},
-		"log-symbols": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
 		"longest-streak": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
@@ -3910,9 +3489,9 @@
 			"integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
 		},
 		"nth-check": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
-			"integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+			"integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
 			"dev": true,
 			"requires": {
 				"boolbase": "^1.0.0"
@@ -3942,24 +3521,6 @@
 			"integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
 			"dev": true
 		},
-		"object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
-		},
-		"object.assign": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3",
-				"has-symbols": "^1.0.1",
-				"object-keys": "^1.1.1"
-			}
-		},
 		"object.defaults": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
@@ -3970,17 +3531,6 @@
 				"array-slice": "^1.0.0",
 				"for-own": "^1.0.0",
 				"isobject": "^3.0.0"
-			}
-		},
-		"object.getownpropertydescriptors": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
-			"integrity": "sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.2"
 			}
 		},
 		"object.map": {
@@ -4000,17 +3550,6 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
-			}
-		},
-		"object.values": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
-			"integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.2"
 			}
 		},
 		"once": {
@@ -4249,6 +3788,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true
+		},
+		"picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
 			"dev": true
 		},
 		"picomatch": {
@@ -7264,12 +6809,6 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
-		"q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
-		},
 		"qs": {
 			"version": "6.10.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
@@ -7541,12 +7080,6 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"dev": true
-		},
 		"semver": {
 			"version": "7.3.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -7738,26 +7271,6 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.0"
-			}
-		},
-		"string.prototype.trimend": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
-			}
-		},
-		"string.prototype.trimstart": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
 			}
 		},
 		"string_decoder": {
@@ -8362,17 +7875,17 @@
 			"dev": true
 		},
 		"svgo": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.1.tgz",
-			"integrity": "sha512-riDDIQgXpEnn0BEl9Gvhh1LNLIyiusSpt64IR8upJu7MwxnzetmF/Y57pXQD2NMX2lVyMRzXt5f2M5rO4wG7Dw==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+			"integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
 			"dev": true,
 			"requires": {
-				"@trysound/sax": "0.1.1",
-				"chalk": "^4.1.0",
-				"commander": "^7.1.0",
+				"@trysound/sax": "0.2.0",
+				"commander": "^7.2.0",
 				"css-select": "^4.1.3",
-				"css-tree": "^1.1.2",
+				"css-tree": "^1.1.3",
 				"csso": "^4.2.0",
+				"picocolors": "^1.0.0",
 				"stable": "^0.1.8"
 			}
 		},
@@ -8520,18 +8033,6 @@
 			"integrity": "sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==",
 			"dev": true
 		},
-		"unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
-			"dev": true,
-			"requires": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
-				"which-boxed-primitive": "^1.0.2"
-			}
-		},
 		"unc-path-regex": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -8622,12 +8123,6 @@
 				"viewport-dimensions": "^0.2.0"
 			}
 		},
-		"unquote": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-			"dev": true
-		},
 		"upath": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -8654,18 +8149,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true
-		},
-		"util.promisify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
-			"integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.2",
-				"has-symbols": "^1.0.1",
-				"object.getownpropertydescriptors": "^2.1.0"
-			}
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",
@@ -8812,19 +8295,6 @@
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
-			}
-		},
-		"which-boxed-primitive": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-			"dev": true,
-			"requires": {
-				"is-bigint": "^1.0.1",
-				"is-boolean-object": "^1.1.0",
-				"is-number-object": "^1.0.4",
-				"is-string": "^1.0.5",
-				"is-symbol": "^1.0.3"
 			}
 		},
 		"wikimedia-ui-base": {

--- a/package.json
+++ b/package.json
@@ -32,18 +32,19 @@
 		"grunt-exec": "3.0.0",
 		"grunt-replace": "2.0.2",
 		"grunt-stylelint": "0.16.0",
-		"grunt-svgmin": "6.0.1",
 		"pixrem": "5.0.0",
 		"postcss": "8.3.5",
 		"postcss-cssnext": "3.1.0",
 		"postcss-custom-properties": "11.0.0",
 		"postcss-import": "14.0.2",
-		"stylelint-config-wikimedia": "0.11.1"
+		"stylelint-config-wikimedia": "0.11.1",
+		"svgo": "2.8.0"
 	},
 	"scripts": {
 		"start": "grunt watch",
-		"build:squoosh": "squoosh-cli --oxipng '{\"level\": 4}' -d img/apps/ img/apps/*.png && squoosh-cli --oxipng '{\"level\": 4}' -d img/components/ img/components/*.png && squoosh-cli --oxipng '{\"level\": 4}' -d img/design-principles/ img/design-principles/*.png && squoosh-cli --oxipng '{\"level\": 4}' -d img/visual-style/ img/visual-style/*.png && squoosh-cli --oxipng '{\"level\": 4}' -d resources/ resources/!\\(WikimediaUI-components_overview\\).png",
-		"build": "grunt && npx npm-run-all build:*",
+		"minify:svg": "svgo --config=.svgo.config.js --quiet --recursive --folder ./ --exclude principles-paper-ink.svg",
+		"build:squoosh": "squoosh-cli --oxipng '{\"level\": 4}' -d img/components/ img/components/*.png && squoosh-cli --oxipng '{\"level\": 4}' -d img/design-principles/ img/design-principles/*.png && squoosh-cli --oxipng '{\"level\": 4}' -d img/visual-style/ img/visual-style/*.png && squoosh-cli --oxipng '{\"level\": 4}' -d resources/ resources/!\\(WikimediaUI-components_overview\\).png",
+		"build": "npm run minify:svg && grunt && npx npm-run-all build:*",
 		"test": "grunt lint"
 	}
 }


### PR DESCRIPTION
Replacing 'grunt-svgmin' with 'svgo' v2.8.0.
Also
- replacing Grunt based task with npm equivalent including excluded
  SVG file.
- changing to JS based '.svgo.config.js'

#465
Bug: [T246321](https://phabricator.wikimedia.org/T246321)
Bug: [T278656](https://phabricator.wikimedia.org/T278656)