### PR TITLE
build: Update GitHub workflows to check Node 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Also Node 16 as it's the current minimal version on Wikimedia infrastructure.